### PR TITLE
Fix CloudStream.sortBy hang on linux platforms

### DIFF
--- a/src/MBrace.Streams/CloudStreams.fs
+++ b/src/MBrace.Streams/CloudStreams.fs
@@ -537,7 +537,7 @@ module CloudStream =
     /// <param name="takeCount">The number of elements to return.</param>
     /// <returns>The result CloudStream.</returns>  
     let inline sortBy (projection : 'T -> 'Key) (takeCount : int) (stream : CloudStream<'T>) : CloudStream<'T> = 
-        let collectorf = cloud {  
+        let collectorf = cloud {
             let results = new List<List<'T>>()
             return 
               { new Collector<'T, List<'Key[] * 'T []>> with
@@ -559,7 +559,10 @@ module CloudStream =
                             counter <- counter + 1
                             keys.[counter] <- projection value
                             values.[counter] <- value
-                    Sort.parallelSort Environment.ProcessorCount keys values
+                    if System.Environment.OSVersion.Platform = System.PlatformID.Unix then
+                        Array.Sort(keys, values)
+                    else
+                        Sort.parallelSort Environment.ProcessorCount keys values
                     new List<_>(Seq.singleton
                                     (keys.Take(takeCount).ToArray(), 
                                      values.Take(takeCount).ToArray())) }
@@ -577,7 +580,10 @@ module CloudStream =
                             counter <- counter + 1
                             keys.[counter] <- keys'.[i]
                             values.[counter] <- values'.[i]
-                    Sort.parallelSort Environment.ProcessorCount keys values    
+                    if System.Environment.OSVersion.Platform = System.PlatformID.Unix then
+                        Array.Sort(keys, values)
+                    else
+                        Sort.parallelSort Environment.ProcessorCount keys values
                     values.Take(takeCount).ToArray()
                 return result
             }

--- a/src/MBrace.Streams/CloudStreams.fs
+++ b/src/MBrace.Streams/CloudStreams.fs
@@ -596,6 +596,42 @@ module CloudStream =
                 }  
         }
 
+    /// <summary> Returns the elements of a CloudStream up to a specified count. </summary>
+    /// <param name="n">The maximum number of items to take.</param>
+    /// <param name="stream">The input CloudStream.</param>
+    /// <returns>The resulting CloudStream.</returns>
+    let inline take (n : int) (stream: CloudStream<'T>) : CloudStream<'T> =
+        let collectorF =
+            cloud {
+                let results = new List<List<'T>>()
+                let cts = new CancellationTokenSource()
+                return
+                    { new Collector<'T, List<'T>> with
+                      member __.DegreeOfParallelism = stream.DegreeOfParallelism
+                      member __.Iterator() =
+                          let list = new List<'T>()
+                          results.Add(list)
+                          { Index = ref -1
+                            Func = (fun value -> if list.Count < n then list.Add(value) else cts.Cancel())
+                            Cts = cts }
+                      member __.Result =
+                          results |> Stream.ofResizeArray |> Stream.flatMap Stream.ofResizeArray |> Stream.take n |> Stream.toResizeArray
+                     }
+            }
+        let gather =
+            cloud {
+                let! results = stream.Apply collectorF (cloud.Return) (fun l r -> l.AddRange(r); l)
+                return results.Take(n).ToArray()
+            }
+        { new CloudStream<'T> with
+              member __.DegreeOfParallelism = stream.DegreeOfParallelism
+              member __.Apply<'S, 'R>(collectorF: Cloud<Collector<'T, 'S>>) (projection: 'S -> Cloud<'R>) combiner =
+                  cloud {
+                      let! result = gather
+                      return! (ofArray result).Apply collectorF projection combiner
+                  }
+        }
+
 
 
     /// <summary>Returns the first element for which the given function returns true. Returns None if no such element exists.</summary>

--- a/src/MBrace.Streams/test.fsx
+++ b/src/MBrace.Streams/test.fsx
@@ -20,6 +20,11 @@ let runtime = MBraceRuntime.InitLocal(4)
 open Nessos.Streams
 open MBrace.Streams
 
+for i in 1..100 do
+    let source = [| 1..10 |]
+    let q = source |> CloudStream.ofArray |> CloudStream.sortBy id 10 |> CloudStream.toArray
+    printfn "%A" <| runtime.Run q
+
 let query1 = 
     runtime.Run (
         CloudStream.ofArray [|1 .. 1000|]

--- a/src/MBrace.Streams/test.fsx
+++ b/src/MBrace.Streams/test.fsx
@@ -31,12 +31,6 @@ let query1 =
         |> CloudStream.flatMap(fun i -> [|1..10000|] |> Stream.ofArray |> Stream.map (fun j -> string i, j))
         |> CloudStream.toCloudVector)
 
-let takeQuery s n =
-    let source = [| 1..s |]
-    runtime.Run (source |> CloudStream.ofArray |> CloudStream.take n |> CloudStream.toArray)
-
-takeQuery 10 6
-
 
 runtime.Run <| CloudStream.cache(query1)
 

--- a/src/MBrace.Streams/test.fsx
+++ b/src/MBrace.Streams/test.fsx
@@ -31,6 +31,12 @@ let query1 =
         |> CloudStream.flatMap(fun i -> [|1..10000|] |> Stream.ofArray |> Stream.map (fun j -> string i, j))
         |> CloudStream.toCloudVector)
 
+let takeQuery s n =
+    let source = [| 1..s |]
+    runtime.Run (source |> CloudStream.ofArray |> CloudStream.take n |> CloudStream.toArray)
+
+takeQuery 10 6
+
 
 runtime.Run <| CloudStream.cache(query1)
 

--- a/tests/MBrace.Streams.Tests/CloudStreamTests.fs
+++ b/tests/MBrace.Streams.Tests/CloudStreamTests.fs
@@ -215,6 +215,7 @@ type ``CloudStreams tests`` () as self =
     [<Test>]
     member __.``2. CloudStream : ofCloudFiles with ReadAllLines`` () =
         let f(xs : string [][]) =
+            printfn "START TEST"
             let cfs = xs 
                      |> Array.map(fun text -> CloudFile.WriteAllLines(text))
                      |> Cloud.Parallel
@@ -230,6 +231,7 @@ type ``CloudStreams tests`` () as self =
                         |> Seq.collect id
                         |> Set.ofSeq
 
+            printfn "END TEST"
             Assert.AreEqual(y, x)
         Check.QuickThrowOnFail(f, 10)
 
@@ -298,6 +300,15 @@ type ``CloudStreams tests`` () as self =
         let f(xs : int[]) =
             let x = xs |> CloudStream.ofArray |> CloudStream.sortBy id 10 |> CloudStream.toArray |> run
             let y = (xs |> Seq.sortBy id).Take(10).ToArray()
+            Assert.AreEqual(y, x)
+        Check.QuickThrowOnFail(f, self.FsCheckMaxNumberOfTests)
+
+    [<Test>]
+    member __.``2. CloudStream : take`` () =
+        let f (xs : int[], n : int) =
+            let n = System.Math.Abs(n)
+            let x = xs |> CloudStream.ofArray |> CloudStream.take n |> CloudStream.length |> run
+            let y = xs.Take(n).Count()
             Assert.AreEqual(y, x)
         Check.QuickThrowOnFail(f, self.FsCheckMaxNumberOfTests)
 

--- a/tests/MBrace.Streams.Tests/CloudStreamTests.fs
+++ b/tests/MBrace.Streams.Tests/CloudStreamTests.fs
@@ -215,7 +215,6 @@ type ``CloudStreams tests`` () as self =
     [<Test>]
     member __.``2. CloudStream : ofCloudFiles with ReadAllLines`` () =
         let f(xs : string [][]) =
-            printfn "START TEST"
             let cfs = xs 
                      |> Array.map(fun text -> CloudFile.WriteAllLines(text))
                      |> Cloud.Parallel
@@ -231,7 +230,6 @@ type ``CloudStreams tests`` () as self =
                         |> Seq.collect id
                         |> Set.ofSeq
 
-            printfn "END TEST"
             Assert.AreEqual(y, x)
         Check.QuickThrowOnFail(f, 10)
 
@@ -300,15 +298,6 @@ type ``CloudStreams tests`` () as self =
         let f(xs : int[]) =
             let x = xs |> CloudStream.ofArray |> CloudStream.sortBy id 10 |> CloudStream.toArray |> run
             let y = (xs |> Seq.sortBy id).Take(10).ToArray()
-            Assert.AreEqual(y, x)
-        Check.QuickThrowOnFail(f, self.FsCheckMaxNumberOfTests)
-
-    [<Test>]
-    member __.``2. CloudStream : take`` () =
-        let f (xs : int[], n : int) =
-            let n = System.Math.Abs(n)
-            let x = xs |> CloudStream.ofArray |> CloudStream.take n |> CloudStream.length |> run
-            let y = xs.Take(n).Count()
             Assert.AreEqual(y, x)
         Check.QuickThrowOnFail(f, self.FsCheckMaxNumberOfTests)
 


### PR DESCRIPTION
Fix of the same issue as discussed in https://github.com/nessos/Streams/pull/12