### PR TITLE
Amend Local workflows design

### DIFF
--- a/samples/MBrace.SampleRuntime/Client.fs
+++ b/samples/MBrace.SampleRuntime/Client.fs
@@ -90,7 +90,7 @@ type MBraceRuntime private (?fileStore : ICloudFileStore, ?serializer : ISeriali
     /// <param name="workflow">Workflow to be executed.</param>
     /// <param name="cancellationToken">Cancellation token for computation.</param>
     /// <param name="faultPolicy">Fault policy. Defaults to infinite retries.</param>
-    member __.StartAsTaskAsync(workflow : Workflow<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy : FaultPolicy) : Async<ICloudTask<'T>> = async {
+    member __.StartAsTaskAsync(workflow : Cloud<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy : FaultPolicy) : Async<ICloudTask<'T>> = async {
         let faultPolicy = match faultPolicy with Some fp -> fp | None -> FaultPolicy.InfiniteRetry()
         let dependencies = VagabondRegistry.ComputeObjectDependencies ((workflow, fileStore, serializer))
         let processInfo = createProcessInfo ()
@@ -110,7 +110,7 @@ type MBraceRuntime private (?fileStore : ICloudFileStore, ?serializer : ISeriali
     /// <param name="workflow">Workflow to be executed.</param>
     /// <param name="cancellationToken">Cancellation token for computation.</param>
     /// <param name="faultPolicy">Fault policy. Defaults to infinite retries.</param>
-    member __.StartAsTask(workflow : Workflow<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy : FaultPolicy) : ICloudTask<'T> =
+    member __.StartAsTask(workflow : Cloud<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy : FaultPolicy) : ICloudTask<'T> =
         __.StartAsTaskAsync(workflow, ?cancellationToken = cancellationToken, ?faultPolicy = faultPolicy) |> Async.RunSync
 
 
@@ -120,7 +120,7 @@ type MBraceRuntime private (?fileStore : ICloudFileStore, ?serializer : ISeriali
     /// <param name="workflow">Workflow to be executed.</param>
     /// <param name="cancellationToken">Cancellation token for computation.</param>
     /// <param name="faultPolicy">Fault policy. Defaults to infinite retries.</param>
-    member __.RunAsync(workflow : Workflow<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy) = async {
+    member __.RunAsync(workflow : Cloud<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy) = async {
         let! cts = async {
             match cancellationToken with 
             | Some ct -> return ct :?> DistributedCancellationTokenSource
@@ -140,14 +140,14 @@ type MBraceRuntime private (?fileStore : ICloudFileStore, ?serializer : ISeriali
     /// <param name="workflow">Workflow to be executed.</param>
     /// <param name="cancellationToken">Cancellation token for computation.</param>
     /// <param name="faultPolicy">Fault policy. Defaults to infinite retries.</param>
-    member __.Run(workflow : Workflow<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy : FaultPolicy) =
+    member __.Run(workflow : Cloud<'T>, ?cancellationToken : ICloudCancellationToken, ?faultPolicy : FaultPolicy) =
         __.RunAsync(workflow, ?cancellationToken = cancellationToken, ?faultPolicy = faultPolicy) |> Async.RunSync
 
     /// <summary>
     ///     Run workflow as local, in-memory computation
     /// </summary>
     /// <param name="workflow">Workflow to execute</param>
-    member __.RunLocalAsync(workflow : Workflow<'T>) : Async<'T> = imem.RunAsync workflow
+    member __.RunLocalAsync(workflow : Cloud<'T>) : Async<'T> = imem.RunAsync workflow
 
     /// Returns the store client for provided runtime
     member __.StoreClient = imem.StoreClient

--- a/samples/MBrace.SampleRuntime/Combinators.fs
+++ b/samples/MBrace.SampleRuntime/Combinators.fs
@@ -19,7 +19,7 @@ let inline private withCancellationToken (cts : ICloudCancellationToken) (ctx : 
 let private asyncFromContinuations f =
     Cloud.FromContinuations(fun ctx cont -> JobExecutionMonitor.ProtectAsync ctx (f ctx cont))
         
-let Parallel (state : RuntimeState) procInfo dependencies fp (computations : seq<#Workflow<'T> * IWorkerRef option>) =
+let Parallel (state : RuntimeState) procInfo dependencies fp (computations : seq<#Cloud<'T> * IWorkerRef option>) =
     asyncFromContinuations(fun ctx cont -> async {
         match (try Seq.toArray computations |> Choice1Of2 with e -> Choice2Of2 e) with
         | Choice2Of2 e -> cont.Exception ctx (ExceptionDispatchInfo.Capture e)
@@ -29,7 +29,7 @@ let Parallel (state : RuntimeState) procInfo dependencies fp (computations : seq
         | Choice1Of2 [| (comp, None) |] ->
             let (comp, cont) = Config.Pickler.Clone (comp, cont)
             let cont' = Continuation.map (fun t -> [| t |]) cont
-            Workflow.StartWithContinuations(comp, cont', ctx)
+            Cloud.StartWithContinuations(comp, cont', ctx)
 
         | Choice1Of2 computations ->
             // request runtime resources required for distribution coordination
@@ -77,7 +77,7 @@ let Parallel (state : RuntimeState) procInfo dependencies fp (computations : seq
                     
             JobExecutionMonitor.TriggerCompletion ctx })
 
-let Choice (state : RuntimeState) procInfo dependencies fp (computations : seq<#Workflow<'T option> * IWorkerRef option>) =
+let Choice (state : RuntimeState) procInfo dependencies fp (computations : seq<#Cloud<'T option> * IWorkerRef option>) =
     asyncFromContinuations(fun ctx cont -> async {
         match (try Seq.toArray computations |> Choice1Of2 with e -> Choice2Of2 e) with
         | Choice2Of2 e -> cont.Exception ctx (ExceptionDispatchInfo.Capture e)
@@ -86,7 +86,7 @@ let Choice (state : RuntimeState) procInfo dependencies fp (computations : seq<#
         // force copy semantics by cloning the workflow
         | Choice1Of2 [| (comp, None) |] -> 
             let (comp, cont) = Config.Pickler.Clone (comp, cont)
-            Workflow.StartWithContinuations(comp, cont, ctx)
+            Cloud.StartWithContinuations(comp, cont, ctx)
 
         | Choice1Of2 computations ->
             // request runtime resources required for distribution coordination
@@ -147,7 +147,7 @@ let Choice (state : RuntimeState) procInfo dependencies fp (computations : seq<#
             JobExecutionMonitor.TriggerCompletion ctx })
 
 
-let StartAsCloudTask (state : RuntimeState) procInfo dependencies (ct : ICloudCancellationToken) fp worker (computation : Workflow<'T>) = cloud {
+let StartAsCloudTask (state : RuntimeState) procInfo dependencies (ct : ICloudCancellationToken) fp worker (computation : Cloud<'T>) = cloud {
     let dcts = ct :?> DistributedCancellationTokenSource
     return! Cloud.OfAsync <| state.StartAsTask procInfo dependencies dcts fp worker computation
 }

--- a/samples/MBrace.SampleRuntime/DistributionProvider.fs
+++ b/samples/MBrace.SampleRuntime/DistributionProvider.fs
@@ -134,7 +134,7 @@ type DistributionProvider private (state : RuntimeState, procInfo : ProcessInfo,
                 return! Combinators.Choice state procInfo dependencies faultPolicy computations
         }
 
-        member __.ScheduleStartAsTask(workflow : Workflow<'T>, faultPolicy, cancellationToken, ?target:IWorkerRef) = cloud {
+        member __.ScheduleStartAsTask(workflow : Cloud<'T>, faultPolicy, cancellationToken, ?target:IWorkerRef) = cloud {
             if isForcedLocalParallelism then
                 return invalidOp <| sprintf "cannot initialize cloud task when evaluating as local semantics."
             else

--- a/samples/MBrace.SampleRuntime/Types.fs
+++ b/samples/MBrace.SampleRuntime/Types.fs
@@ -122,12 +122,12 @@ with
     /// <param name="sc">Success continuation</param>
     /// <param name="ec">Exception continuation</param>
     /// <param name="cc">Cancellation continuation</param>
-    /// <param name="wf">Workflow</param>
-    static member Create procInfo dependencies cts fp sc ec cc worker (wf : Workflow<'T>) : PickledJob =
+    /// <param name="wf">Cloud</param>
+    static member Create procInfo dependencies cts fp sc ec cc worker (wf : Cloud<'T>) : PickledJob =
         let jobId = System.Guid.NewGuid().ToString()
         let runJob ctx =
             let cont = { Success = sc ; Exception = ec ; Cancellation = cc }
-            Workflow.StartWithContinuations(wf, cont, ctx)
+            Cloud.StartWithContinuations(wf, cont, ctx)
 
         let job = 
             { 
@@ -201,8 +201,8 @@ with
     /// <param name="sc">Success continuation</param>
     /// <param name="ec">Exception continuation</param>
     /// <param name="cc">Cancellation continuation</param>
-    /// <param name="wf">Workflow</param>
-    member rt.EnqueueJob procInfo dependencies cts fp sc ec cc worker (wf : Workflow<'T>) : unit =
+    /// <param name="wf">Cloud</param>
+    member rt.EnqueueJob procInfo dependencies cts fp sc ec cc worker (wf : Cloud<'T>) : unit =
         rt.JobQueue.Enqueue <| PickledJob.Create procInfo dependencies cts fp sc ec cc worker wf
 
     /// <summary>
@@ -217,7 +217,7 @@ with
     /// <param name="dependencies">Declared workflow dependencies.</param>
     /// <param name="cts">Cancellation token source bound to job.</param>
     /// <param name="wf">Input workflow.</param>
-    member rt.StartAsTask procInfo dependencies cts fp worker (wf : Workflow<'T>) : Async<ICloudTask<'T>> = async {
+    member rt.StartAsTask procInfo dependencies cts fp worker (wf : Cloud<'T>) : Async<ICloudTask<'T>> = async {
         let! resultCell = rt.ResourceFactory.RequestResultCell<'T>()
         let setResult ctx r = 
             async {

--- a/samples/MBrace.SampleRuntime/test.fsx
+++ b/samples/MBrace.SampleRuntime/test.fsx
@@ -69,6 +69,6 @@ runtime.Run(test(), faultPolicy = FaultPolicy.NoRetry)
 Cloud.Parallel [cloud { return 432 } ; local { return 1 } :> _ ]
 
 local {
-    let! x = Cloud.Parallel [ cloud { return 42 } ; ]
+    let! x = Cloud.Parallel [ cloud { return 42 } ]
     return x
 }

--- a/samples/MBrace.SampleRuntime/test.fsx
+++ b/samples/MBrace.SampleRuntime/test.fsx
@@ -66,7 +66,9 @@ let rec test () = cloud {
 runtime.Run(test(), faultPolicy = FaultPolicy.NoRetry)
 
 
+Cloud.Parallel [cloud { return 432 } ; local { return 1 } :> _ ]
+
 local {
-    let! x = Cloud.Parallel [ cloud { return 42 }]
+    let! x = Cloud.Parallel [ cloud { return 42 } ; ]
     return x
 }

--- a/src/MBrace.Core/Client/LocalRuntime.fs
+++ b/src/MBrace.Core/Client/LocalRuntime.fs
@@ -31,7 +31,7 @@ type LocalRuntime private (resources : ResourceRegistry) =
     ///     with parallelism provided by the .NET thread pool.
     /// </summary>
     /// <param name="workflow">Workflow to be executed.</param>
-    member r.RunAsync(workflow : Workflow<'T>) : Async<'T> =
+    member r.RunAsync(workflow : Cloud<'T>) : Async<'T> =
         toLocalAsync resources workflow
 
     /// <summary>
@@ -40,9 +40,9 @@ type LocalRuntime private (resources : ResourceRegistry) =
     /// </summary>
     /// <param name="workflow">Workflow to be executed.</param>
     /// <param name="cancellationToken">Cancellation token passed to computation.</param>
-    member r.Run(workflow : Workflow<'T>, ?cancellationToken : ICloudCancellationToken) : 'T =
+    member r.Run(workflow : Cloud<'T>, ?cancellationToken : ICloudCancellationToken) : 'T =
         let cancellationToken = match cancellationToken with Some ct -> ct | None -> new InMemoryCancellationToken() :> _
-        Workflow.RunSynchronously(workflow, resources, cancellationToken)
+        Cloud.RunSynchronously(workflow, resources, cancellationToken)
 
     /// <summary>
     ///     Executes a cloud computation in the local process,
@@ -50,9 +50,9 @@ type LocalRuntime private (resources : ResourceRegistry) =
     /// </summary>
     /// <param name="workflow">Workflow to be executed.</param>
     /// <param name="cancellationToken">Cancellation token passed to computation.</param>
-    member r.Run(workflow : Workflow<'T>, cancellationToken : CancellationToken) : 'T =
+    member r.Run(workflow : Cloud<'T>, cancellationToken : CancellationToken) : 'T =
         let cancellationToken = new InMemoryCancellationToken(cancellationToken)
-        Workflow.RunSynchronously(workflow, resources, cancellationToken)
+        Cloud.RunSynchronously(workflow, resources, cancellationToken)
 
     /// Creates a new cancellation token source
     member r.CreateCancellationTokenSource() = 

--- a/src/MBrace.Core/Client/StoreClient.fs
+++ b/src/MBrace.Core/Client/StoreClient.fs
@@ -15,7 +15,7 @@ module internal ClientUtils =
 
     let toLocalAsync resources wf = async {
         let! ct = Async.CancellationToken
-        return! Workflow.ToAsync(wf, resources, new InMemoryCancellationToken(ct))
+        return! Cloud.ToAsync(wf, resources, new InMemoryCancellationToken(ct))
     }
 
 [<Sealed; AutoSerializable(false)>]

--- a/src/MBrace.Core/Continuation/Cloud.fs
+++ b/src/MBrace.Core/Continuation/Cloud.fs
@@ -1,8 +1,10 @@
 ﻿namespace MBrace
 
+open System.Runtime.Serialization
+
 open MBrace.Continuation
 
-// Workflow<'T> is a continuation-based computation that can be distributed.
+// Cloud<'T> is a continuation-based computation that can be distributed.
 // It takes two parameters, an ExecutionContext and a continuation triple.
 // Importantly, the two values must remain distinct in order for distribution
 // to be actuated effectively. ExecutionContext contains resources specific
@@ -18,21 +20,20 @@ type internal Body<'T> = ExecutionContext -> Continuation<'T> -> unit
 
 /// Representation of an MBrace workflow, which, when run 
 /// will produce a value of type 'T, or raise an exception.
-[<AbstractClass>]
-type Workflow<'T> internal (body : Body<'T>) =
-    member internal __.Body = body
+/// Representation of a cloud computation, which, when run 
+/// will produce a value of type 'T, or raise an exception.
+[<DataContract>]
+type Cloud<'T> =
+    [<DataMember(Name = "Body")>]
+    val mutable private body : Body<'T>
+    internal new (body : Body<'T>) = { body = body}
+    member internal __.Body = __.body
 
 /// Representation of an in-memory computation, which, when run 
 /// will produce a value of type 'T, or raise an exception.
-[<Sealed; AutoSerializable(true)>]
+[<Sealed; DataContract>]
 type Local<'T> internal (body : Body<'T>) = 
-    inherit Workflow<'T>(body)
-
-/// Representation of a cloud computation, which, when run 
-/// will produce a value of type 'T, or raise an exception.
-[<Sealed; AutoSerializable(true)>]
-type Cloud<'T> internal (body : Body<'T>) = 
-    inherit Workflow<'T>(body)
+    inherit Cloud<'T>(body)
 
 /// Adding this attribute to a let-binding marks that
 /// the value definition contains cloud expressions.

--- a/src/MBrace.Core/Continuation/Cloud.fs
+++ b/src/MBrace.Core/Continuation/Cloud.fs
@@ -26,7 +26,7 @@ type internal Body<'T> = ExecutionContext -> Continuation<'T> -> unit
 type Cloud<'T> =
     [<DataMember(Name = "Body")>]
     val mutable private body : Body<'T>
-    internal new (body : Body<'T>) = { body = body}
+    internal new (body : Body<'T>) = { body = body }
     member internal __.Body = __.body
 
 /// Representation of an in-memory computation, which, when run 

--- a/src/MBrace.Core/Distribution/DistributionProvider.fs
+++ b/src/MBrace.Core/Distribution/DistributionProvider.fs
@@ -56,13 +56,13 @@ type IDistributionProvider =
     ///     Parallel fork/join implementation.
     /// </summary>
     /// <param name="computations">Computations to be executed. Contains optional target worker.</param>
-    abstract ScheduleParallel : computations:seq<#Workflow<'T> * IWorkerRef option> -> Cloud<'T []>
+    abstract ScheduleParallel : computations:seq<#Cloud<'T> * IWorkerRef option> -> Cloud<'T []>
 
     /// <summary>
     ///     Parallel nondeterministic choice implementation.
     /// </summary>
     /// <param name="computations">Computations to be executed. Contains optional target worker.</param>
-    abstract ScheduleChoice : computations:seq<#Workflow<'T option> * IWorkerRef option> -> Cloud<'T option>
+    abstract ScheduleChoice : computations:seq<#Cloud<'T option> * IWorkerRef option> -> Cloud<'T option>
 
     /// <summary>
     ///     Parallel fork/join implementation.
@@ -83,4 +83,4 @@ type IDistributionProvider =
     /// <param name="faultPolicy">Fault policy for new task.</param>
     /// <param name="cancellationToken">Cancellation token for task. Defaults to no cancellation token.</param>
     /// <param name="target">Explicitly specify a target worker for execution.</param>
-    abstract ScheduleStartAsTask : workflow:Workflow<'T> * faultPolicy:FaultPolicy * cancellationToken:ICloudCancellationToken * ?target:IWorkerRef -> Cloud<ICloudTask<'T>>
+    abstract ScheduleStartAsTask : workflow:Cloud<'T> * faultPolicy:FaultPolicy * cancellationToken:ICloudCancellationToken * ?target:IWorkerRef -> Cloud<ICloudTask<'T>>

--- a/src/MBrace.Core/Distribution/InMemory/InMemoryRuntime.fs
+++ b/src/MBrace.Core/Distribution/InMemory/InMemoryRuntime.fs
@@ -130,11 +130,11 @@ type ThreadPoolRuntime private (faultPolicy : FaultPolicy, logger : ICloudLogger
         member __.ScheduleLocalParallel computations = ThreadPool.Parallel(mkNestedCts, computations)
         member __.ScheduleLocalChoice computations = ThreadPool.Choice(mkNestedCts, computations)
 
-        member __.ScheduleStartAsTask (workflow:Workflow<'T>, faultPolicy:FaultPolicy, cancellationToken:ICloudCancellationToken, ?target:IWorkerRef) = cloud {
+        member __.ScheduleStartAsTask (workflow:Cloud<'T>, faultPolicy:FaultPolicy, cancellationToken:ICloudCancellationToken, ?target:IWorkerRef) = cloud {
             target |> Option.iter (fun _ -> raise <| new System.NotSupportedException("Targeted workers not supported in In-Memory runtime."))
-            let! resources = Workflow.GetResourceRegistry()
+            let! resources = Cloud.GetResourceRegistry()
             let runtimeP = new ThreadPoolRuntime(faultPolicy, logger) 
             let resources' = resources.Register (runtimeP :> IDistributionProvider)
-            let task = Workflow.StartAsTask(workflow, resources', cancellationToken)
+            let task = Cloud.StartAsTask(workflow, resources', cancellationToken)
             return new InMemoryTask<'T>(task) :> _
         }

--- a/src/MBrace.Core/MBrace.Core.fsproj
+++ b/src/MBrace.Core/MBrace.Core.fsproj
@@ -64,7 +64,7 @@
     <Compile Include="Continuation\ExceptionDispatchInfo.fs" />
     <Compile Include="Continuation\CancellationToken.fs" />
     <Compile Include="Continuation\ExecutionContext.fs" />
-    <Compile Include="Continuation\Workflow.fs" />
+    <Compile Include="Continuation\Cloud.fs" />
     <Compile Include="Continuation\Builders.fs" />
     <Compile Include="Continuation\ContinuationAPI.fs" />
     <Compile Include="Store\Serializer.fs" />

--- a/src/MBrace.Core/Store/Atom.fs
+++ b/src/MBrace.Core/Store/Atom.fs
@@ -112,7 +112,7 @@ type CloudAtom =
     /// </summary>
     /// <param name="initial">Initial value.</param>
     static member New<'T>(initial : 'T, ?container : string) : Local<ICloudAtom<'T>> = local {
-        let! config = Workflow.GetResource<CloudAtomConfiguration> ()
+        let! config = Cloud.GetResource<CloudAtomConfiguration> ()
         let container = defaultArg container config.DefaultContainer
         return! ofAsync <| config.AtomProvider.CreateAtom(container, initial)
     }
@@ -165,13 +165,13 @@ type CloudAtom =
     /// </summary>
     /// <param name="container"></param>
     static member DeleteContainer (container : string) : Local<unit> = local {
-        let! config = Workflow.GetResource<CloudAtomConfiguration> ()
+        let! config = Cloud.GetResource<CloudAtomConfiguration> ()
         return! ofAsync <| config.AtomProvider.DisposeContainer container
     }
 
     /// Generates a unique container name.
     static member CreateContainerName() = local {
-        let! config = Workflow.GetResource<CloudAtomConfiguration> ()
+        let! config = Cloud.GetResource<CloudAtomConfiguration> ()
         return config.AtomProvider.CreateUniqueContainerName()
     }
 
@@ -180,7 +180,7 @@ type CloudAtom =
     /// </summary>
     /// <param name="value">Value to be checked.</param>
     static member IsSupportedValue(value : 'T) = local {
-        let! config = Workflow.TryGetResource<CloudAtomConfiguration> ()
+        let! config = Cloud.TryGetResource<CloudAtomConfiguration> ()
         return
             match config with
             | None -> false

--- a/src/MBrace.Core/Store/Channel.fs
+++ b/src/MBrace.Core/Store/Channel.fs
@@ -88,7 +88,7 @@ type CloudChannel =
     /// </summary>
     /// <param name="container">Container to channel. Defaults to process default.</param>
     static member New<'T>(?container : string) = local {
-        let! config = Workflow.GetResource<CloudChannelConfiguration> ()
+        let! config = Cloud.GetResource<CloudChannelConfiguration> ()
         let container = defaultArg container config.DefaultContainer
         return! ofAsync <| config.ChannelProvider.CreateChannel<'T> (container)
     }
@@ -123,12 +123,12 @@ type CloudChannel =
     /// </summary>
     /// <param name="container"></param>
     static member DeleteContainer (container : string) = local {
-        let! config = Workflow.GetResource<CloudChannelConfiguration> ()
+        let! config = Cloud.GetResource<CloudChannelConfiguration> ()
         return! ofAsync <| config.ChannelProvider.DisposeContainer container
     }
 
     /// Generates a unique container name.
     static member CreateContainerName() = local {
-        let! config = Workflow.GetResource<CloudChannelConfiguration> ()
+        let! config = Cloud.GetResource<CloudChannelConfiguration> ()
         return config.ChannelProvider.CreateUniqueContainerName()
     }

--- a/src/MBrace.Core/Store/CloudFile.fs
+++ b/src/MBrace.Core/Store/CloudFile.fs
@@ -26,7 +26,7 @@ type FileStore =
 
     /// Returns the file store instance carried in current execution context.
     static member Current = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore
     }
 
@@ -35,7 +35,7 @@ type FileStore =
     /// </summary>
     /// <param name="path">Input file path.</param>
     static member GetDirectoryName(path : string) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.GetDirectoryName path
     }
 
@@ -44,7 +44,7 @@ type FileStore =
     /// </summary>
     /// <param name="path">Input file path.</param>
     static member GetFileName(path : string) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.GetFileName path
     }
 
@@ -54,7 +54,7 @@ type FileStore =
     /// <param name="path1">First path.</param>
     /// <param name="path2">Second path.</param>
     static member Combine(path1 : string, path2 : string) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.Combine [| path1 ; path2 |]
     }
 
@@ -65,7 +65,7 @@ type FileStore =
     /// <param name="path2">Second path.</param>
     /// <param name="path3">Third path.</param>
     static member Combine(path1 : string, path2 : string, path3 : string) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.Combine [| path1 ; path2 ; path3 |]
     }
 
@@ -74,7 +74,7 @@ type FileStore =
     /// </summary>
     /// <param name="paths">Strings to be combined.</param>
     static member Combine(paths : string []) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.Combine paths
     }
 
@@ -84,13 +84,13 @@ type FileStore =
     /// <param name="directory">Directory prefix path.</param>
     /// <param name="fileNames">File names to be combined.</param>
     static member Combine(directory : string, fileNames : seq<string>) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.Combine(directory, fileNames)
     }
 
     /// Generates a random, uniquely specified path to directory
     static member GetRandomDirectoryName() = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return config.FileStore.GetRandomDirectoryName()
     }
 
@@ -99,7 +99,7 @@ type FileStore =
     /// </summary>
     /// <param name="container">Path to containing directory. Defaults to process directory.</param>
     static member GetRandomFileName(?container : string) : Local<string> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         let container = match container with Some c -> c | None -> config.DefaultDirectory
         return config.FileStore.GetRandomFilePath(container)
     }
@@ -138,7 +138,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="directory">Path to directory.</param>
     static member Exists(directory : string) : Local<bool> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return! ofAsync <| config.FileStore.DirectoryExists directory
     }
 
@@ -154,7 +154,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="directory">Path to directory. Defaults to randomly generated directory.</param>
     static member Create(?directory : string) : Local<CloudDirectory> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         let directory =
             match directory with
             | Some d -> d
@@ -171,7 +171,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// <param name="recursiveDelete">Delete recursively. Defaults to false.</param>
     static member Delete(directory : string, ?recursiveDelete : bool) : Local<unit> = local {
         let recursiveDelete = defaultArg recursiveDelete false
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return! ofAsync <| config.FileStore.DeleteDirectory(directory, recursiveDelete = recursiveDelete)
     }
 
@@ -188,7 +188,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="directory">Directory to be enumerated. Defaults to root directory.</param>
     static member Enumerate(?directory : string) : Local<CloudDirectory []> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         let directory =
             match directory with
             | Some d -> d
@@ -231,7 +231,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="path">Input file.</param>
     static member GetSize(path : string) : Local<int64> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return! ofAsync <| config.FileStore.GetFileSize path
     }
 
@@ -247,7 +247,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="path">Input file.</param>
     static member Exists(path : string) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return! ofAsync <| config.FileStore.FileExists path
     }
 
@@ -263,7 +263,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="path">Input file.</param>
     static member Delete(path : string) = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return! ofAsync <| config.FileStore.DeleteFile path
     }
 
@@ -280,7 +280,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// <param name="serializer">Serializer function.</param>
     /// <param name="path">Path to file. Defaults to auto-generated path.</param>
     static member Create(serializer : Stream -> Async<unit>, ?path : string) : Local<CloudFile> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         let path = match path with Some p -> p | None -> config.FileStore.GetRandomFilePath config.DefaultDirectory
         do! ofAsync <| config.FileStore.Write(path, serializer)
         return new CloudFile(path)
@@ -293,7 +293,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// <param name="directory">Containing directory.</param>
     /// <param name="fileName">File name.</param>
     static member Create(serializer : Stream -> Async<unit>, directory : string, fileName : string) : Local<CloudFile> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         let path = config.FileStore.Combine [|directory ; fileName|]
         do! ofAsync <| config.FileStore.Write(path, serializer)
         return new CloudFile(path)
@@ -307,7 +307,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// <param name="leaveOpen">Do not dispose stream after deserialization. Defaults to false.</param>
     static member Read<'T>(path : string, deserializer : Stream -> Async<'T>, ?leaveOpen : bool) : Local<'T> = local {
         let leaveOpen = defaultArg leaveOpen false
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         return! ofAsync <| async {
             if leaveOpen then
                 let! stream = config.FileStore.BeginRead(path)
@@ -331,7 +331,7 @@ and [<DataContract; Sealed; StructuredFormatDisplay("{StructuredFormatDisplay}")
     /// </summary>
     /// <param name="directory">Path to directory. Defaults to the process directory.</param>
     static member Enumerate(?directory : string) : Local<CloudFile []> = local {
-        let! config = Workflow.GetResource<CloudFileStoreConfiguration> ()
+        let! config = Cloud.GetResource<CloudFileStoreConfiguration> ()
         let directory =
             match directory with
             | Some d -> d

--- a/src/MBrace.Core/Workflows/Common.fs
+++ b/src/MBrace.Core/Workflows/Common.fs
@@ -68,7 +68,7 @@ module CloudOperators =
     /// </summary>
     /// <param name="left">The first cloud computation.</param>
     /// <param name="right">The second cloud computation.</param>
-    let (<||>) (left : Workflow<'a>) (right : Workflow<'b>) : Cloud<'a * 'b> = 
+    let (<||>) (left : Cloud<'a>) (right : Cloud<'b>) : Cloud<'a * 'b> = 
         Cloud.Parallel(left, right)
 
     /// <summary>
@@ -77,7 +77,7 @@ module CloudOperators =
     /// </summary>
     /// <param name="left">The first cloud computation.</param>
     /// <param name="right">The second cloud computation.</param>
-    let (<|>) (left : Workflow<'a>) (right : Workflow<'a>) : Cloud<'a> =
+    let (<|>) (left : Cloud<'a>) (right : Cloud<'a>) : Cloud<'a> =
         cloud {
             let left' = cloud { let! value = left  in return Some (value) }
             let right'= cloud { let! value = right in return Some (value) }

--- a/src/MBrace.Core/Workflows/Sequential.fs
+++ b/src/MBrace.Core/Workflows/Sequential.fs
@@ -87,9 +87,9 @@ module Sequential =
     /// <param name="collector">Collector function.</param>
     /// <param name="source">Source data.</param>
     let lazyCollect (collector : 'T -> Local<#seq<'S>>) (source : seq<'T>) : Local<seq<'S>> = local {
-        let! ctx = Workflow.GetExecutionContext()
+        let! ctx = Cloud.GetExecutionContext()
         return seq {
-            for t in source do yield! Workflow.RunSynchronously(collector t, ctx.Resources, ctx.CancellationToken)
+            for t in source do yield! Cloud.RunSynchronously(collector t, ctx.Resources, ctx.CancellationToken)
         }
     }
 

--- a/tests/MBrace.Core.Tests/ContinuationTests.fs
+++ b/tests/MBrace.Core.Tests/ContinuationTests.fs
@@ -23,8 +23,8 @@ module ``Continuation Tests`` =
     //
 
     let imem = LocalRuntime.Create(ResourceRegistry.Empty)
-    let run (wf : Workflow<'T>) = Choice.protect(fun () -> imem.Run wf)
-    let runCts (wf : ICloudCancellationTokenSource -> #Workflow<'T>) =
+    let run (wf : Cloud<'T>) = Choice.protect(fun () -> imem.Run wf)
+    let runCts (wf : ICloudCancellationTokenSource -> #Cloud<'T>) =
         let cts = new InMemoryCancellationTokenSource ()
         Choice.protect(fun () -> imem.Run(wf cts, cts.Token))
 
@@ -494,7 +494,7 @@ module ``Continuation Tests`` =
                                     (fun ctx -> { ctx with Resources = ctx.Resources.Register 42 }),
                                     (fun ctx -> { ctx with Resources = ctx.Resources.Remove<int> ()}))
 
-            return! Workflow.TryGetResource<int> ()
+            return! Cloud.TryGetResource<int> ()
         } |> run |> Choice.shouldEqual None
 
 
@@ -506,7 +506,7 @@ module ``Continuation Tests`` =
 
     [<Test>]
     let ``start as task`` () =
-        let t = Workflow.StartAsTask(cloud { return 42 }, ResourceRegistry.Empty, new InMemoryCancellationToken())
+        let t = Cloud.StartAsTask(cloud { return 42 }, ResourceRegistry.Empty, new InMemoryCancellationToken())
         t.Result |> shouldEqual 42
 
     //

--- a/tests/MBrace.Core.Tests/InMemoryTests.fs
+++ b/tests/MBrace.Core.Tests/InMemoryTests.fs
@@ -25,13 +25,13 @@ type ``ThreadPool Parallelism Tests`` () =
     let logger = InMemoryLogTester()
     let imem = LocalRuntime.Create(logger = logger)
 
-    override __.Run(workflow : Workflow<'T>) = Choice.protect (fun () -> imem.Run(workflow))
-    override __.Run(workflow : ICloudCancellationTokenSource -> #Workflow<'T>) =
+    override __.Run(workflow : Cloud<'T>) = Choice.protect (fun () -> imem.Run(workflow))
+    override __.Run(workflow : ICloudCancellationTokenSource -> #Cloud<'T>) =
         let cts = imem.CreateCancellationTokenSource()
         Choice.protect(fun () ->
             imem.Run(workflow cts, cancellationToken = cts.Token))
 
-    override __.RunLocal(workflow : Workflow<'T>) = imem.Run(workflow)
+    override __.RunLocal(workflow : Cloud<'T>) = imem.Run(workflow)
     override __.IsTargetWorkerSupported = false
     override __.Logs = logger :> _
     override __.FsCheckMaxTests = 100

--- a/tests/MBrace.Core.Tests/ParallelismTests.fs
+++ b/tests/MBrace.Core.Tests/ParallelismTests.fs
@@ -29,16 +29,16 @@ type ``Parallelism Tests`` (parallelismFactor : int, delayFactor : int) as self 
 
     let repeat f = repeat self.Repeats f
 
-    let run (workflow : Workflow<'T>) = self.Run workflow
-    let runCts (workflow : ICloudCancellationTokenSource -> #Workflow<'T>) = self.Run workflow
-    let runLocal (workflow : Workflow<'T>) = self.RunLocal workflow
+    let run (workflow : Cloud<'T>) = self.Run workflow
+    let runCts (workflow : ICloudCancellationTokenSource -> #Cloud<'T>) = self.Run workflow
+    let runLocal (workflow : Cloud<'T>) = self.RunLocal workflow
     
     /// Run workflow in the runtime under test
-    abstract Run : workflow:Workflow<'T> -> Choice<'T, exn>
+    abstract Run : workflow:Cloud<'T> -> Choice<'T, exn>
     /// Run workflow in the runtime under test, with cancellation token source passed to the worker
-    abstract Run : workflow:(ICloudCancellationTokenSource -> #Workflow<'T>) -> Choice<'T, exn>
+    abstract Run : workflow:(ICloudCancellationTokenSource -> #Cloud<'T>) -> Choice<'T, exn>
     /// Evaluate workflow in the local test process
-    abstract RunLocal : workflow:Workflow<'T> -> 'T
+    abstract RunLocal : workflow:Cloud<'T> -> 'T
     /// Maximum number of tests to be run by FsCheck
     abstract FsCheckMaxTests : int
     /// Maximum number of repeats to run nondeterministic tests

--- a/tests/MBrace.Core.Tests/StoreTests/CloudAtomTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/CloudAtomTests.fs
@@ -23,9 +23,9 @@ type ``CloudAtom Tests`` (parallelismFactor : int) as self =
         with e -> Choice2Of2 e
 
     /// Run workflow in the runtime under test
-    abstract Run : Workflow<'T> -> 'T
+    abstract Run : Cloud<'T> -> 'T
     /// Evaluate workflow in the local test process
-    abstract RunLocal : Workflow<'T> -> 'T
+    abstract RunLocal : Cloud<'T> -> 'T
     /// Local store client instance
     abstract AtomClient : CloudAtomClient
     /// Maximum number of repeats to run nondeterministic tests

--- a/tests/MBrace.Core.Tests/StoreTests/CloudChannelTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/CloudChannelTests.fs
@@ -20,9 +20,9 @@ type ``CloudChannel Tests`` (parallelismFactor : int) as self =
         with e -> Choice2Of2 e
 
     /// Run workflow in the runtime under test
-    abstract Run : Workflow<'T> -> 'T
+    abstract Run : Cloud<'T> -> 'T
     /// Evaluate workflow in the local test process
-    abstract RunLocal : Workflow<'T> -> 'T
+    abstract RunLocal : Cloud<'T> -> 'T
     /// Local store client instance
     abstract ChannelClient : CloudChannelClient
 

--- a/tests/MBrace.Core.Tests/StoreTests/FileStoreTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/FileStoreTests.fs
@@ -23,9 +23,9 @@ type ``FileStore Tests`` (parallelismFactor : int) as self =
         with e -> Choice2Of2 e
 
     /// Run workflow in the runtime under test
-    abstract Run : Workflow<'T> -> 'T
+    abstract Run : Cloud<'T> -> 'T
     /// Evaluate workflow in the local test process
-    abstract RunLocal : Workflow<'T> -> 'T
+    abstract RunLocal : Cloud<'T> -> 'T
     /// Store client to be tested
     abstract FileStoreClient : FileStoreClient
     /// denotes that underlying store employs caching

--- a/tests/MBrace.SampleRuntime.Tests/ParallelismTests.fs
+++ b/tests/MBrace.SampleRuntime.Tests/ParallelismTests.fs
@@ -19,7 +19,7 @@ type ``SampleRuntime Parallelism Tests`` () as self =
 
     let session = new RuntimeSession(nodes = 4)
 
-    let run (wf : Workflow<'T>) = self.Run wf
+    let run (wf : Cloud<'T>) = self.Run wf
     let repeat f = repeat self.Repeats f
 
     [<TestFixtureSetUp>]
@@ -30,19 +30,19 @@ type ``SampleRuntime Parallelism Tests`` () as self =
 
     override __.IsTargetWorkerSupported = true
 
-    override __.Run (workflow : Workflow<'T>) = 
+    override __.Run (workflow : Cloud<'T>) = 
         session.Runtime.RunAsync (workflow)
         |> Async.Catch
         |> Async.RunSync
 
-    override __.Run (workflow : ICloudCancellationTokenSource -> #Workflow<'T>) = 
+    override __.Run (workflow : ICloudCancellationTokenSource -> #Cloud<'T>) = 
         async {
             let runtime = session.Runtime
             let cts = runtime.CreateCancellationTokenSource()
             return! runtime.RunAsync(workflow cts, cancellationToken = cts.Token) |> Async.Catch
         } |> Async.RunSync
 
-    override __.RunLocal(workflow : Workflow<'T>) = session.Runtime.RunLocal(workflow)
+    override __.RunLocal(workflow : Cloud<'T>) = session.Runtime.RunLocal(workflow)
 
     override __.Logs = session.Logger :> _
     override __.FsCheckMaxTests = 10

--- a/tests/MBrace.SampleRuntime.Tests/StoreTests.fs
+++ b/tests/MBrace.SampleRuntime.Tests/StoreTests.fs
@@ -19,8 +19,8 @@ type ``SampleRuntime FileStore Tests`` () =
     [<TestFixtureTearDown>]
     member __.Fini () = session.Stop ()
 
-    override __.Run (workflow : Workflow<'T>) = session.Runtime.Run workflow
-    override __.RunLocal(workflow : Workflow<'T>) = session.Runtime.RunLocal workflow
+    override __.Run (workflow : Cloud<'T>) = session.Runtime.Run workflow
+    override __.RunLocal(workflow : Cloud<'T>) = session.Runtime.RunLocal workflow
     override __.FileStoreClient = session.Runtime.StoreClient.FileStore
     override __.IsCachingStore = true
 
@@ -36,8 +36,8 @@ type ``SampleRuntime Atom Tests`` () =
     [<TestFixtureTearDown>]
     member __.Fini () = session.Stop ()
 
-    override __.Run (workflow : Workflow<'T>) = session.Runtime.Run workflow
-    override __.RunLocal(workflow : Workflow<'T>) = session.Runtime.RunLocal workflow
+    override __.Run (workflow : Cloud<'T>) = session.Runtime.Run workflow
+    override __.RunLocal(workflow : Cloud<'T>) = session.Runtime.RunLocal workflow
     override __.AtomClient = session.Runtime.StoreClient.Atom
 #if DEBUG
     override __.Repeats = 10
@@ -56,6 +56,6 @@ type ``SampleRuntime Channel Tests`` () =
     [<TestFixtureTearDown>]
     member __.Fini () = session.Stop ()
 
-    override __.Run (workflow : Workflow<'T>) = session.Runtime.Run workflow
-    override __.RunLocal(workflow : Workflow<'T>) = session.Runtime.RunLocal workflow
+    override __.Run (workflow : Cloud<'T>) = session.Runtime.Run workflow
+    override __.RunLocal(workflow : Cloud<'T>) = session.Runtime.RunLocal workflow
     override __.ChannelClient = session.Runtime.StoreClient.Channel


### PR DESCRIPTION
This PR addresses some of the issues expressed in #9. This abolishes `Workflow<'T>` in favor of a layout where `Cloud<'T>` is the base type and `Local<'T> <: Cloud<'T>`.