### PR TITLE
Question: Is this implementation of foldLocal valid?

### DIFF
--- a/src/MBrace.Streams/CSharpProxy.fs
+++ b/src/MBrace.Streams/CSharpProxy.fs
@@ -26,7 +26,7 @@ type public CSharpProxy =
     static member AggregateBy<'T, 'Key, 'Acc when 'Key : equality>(stream : CloudStream<'T>, projection : Func<'T,'Key> , state : Func<'Acc>, folder : Func<'Acc, 'T, 'Acc>, combiner : Func<'Acc, 'Acc, 'Acc>) = 
         CloudStream.foldBy (fun x -> projection.Invoke(x)) (fun acc x -> folder.Invoke(acc, x)) (fun left right -> combiner.Invoke(left, right)) (fun _ -> state.Invoke()) stream
 
-    static member OrderBy<'T, 'Key when 'Key :> IComparable<'Key>>(stream : CloudStream<'T>, func : Func<'T, 'Key>, takeCount : int) =
+    static member OrderBy<'T, 'Key when 'Key :> IComparable<'Key> and 'Key : comparison>(stream : CloudStream<'T>, func : Func<'T, 'Key>, takeCount : int) =
         CloudStream.sortBy (fun x -> func.Invoke(x)) takeCount stream
 
     static member Count<'T>(stream : CloudStream<'T>) = 

--- a/src/MBrace.Streams/CloudStreams.fs
+++ b/src/MBrace.Streams/CloudStreams.fs
@@ -489,6 +489,12 @@ module CloudStream =
     let iter (action: 'T -> unit) (stream : CloudStream< 'T >) : Cloud< unit > =
         fold (fun () x -> action x) (fun () () -> ()) (fun () -> ()) stream
 
+    /// <summary>Runs the action on each element. The actions are not necessarily performed in order.</summary>
+    /// <param name="stream">The input CloudStream.</param>
+    /// <returns>Nothing.</returns>
+    let iterLocal (action: 'T -> Local<unit>) (stream : CloudStream< 'T >) : Cloud< unit > =
+        foldLocal (fun () x -> action x) (fun () () -> local { return () }) (fun () -> local { return () }) stream
+
     /// <summary>Returns the sum of the elements.</summary>
     /// <param name="stream">The input CloudStream.</param>
     /// <returns>The sum of the elements.</returns>


### PR DESCRIPTION

Hi @paladin, @eiriktsarpalis 

I'm looking at the CloudStream implementation out of curiosity.  Is this kind of implementation of "foldLocal" that allows the map and collect functions to return ``Local<T>`` valid?

It uses

```
            let! ctx = Cloud.GetExecutionContext()
            let run a = Async.RunSync(Cloud.ToAsync(a, ctx.Resources,ctx.CancellationToken))
```

to run the local fragments, is there a better way to do this?

Thanks
Don

