### PR TITLE
New terminal combinator ClouFlow.toCachedCloudVector

### DIFF
--- a/src/MBrace.Flow/CloudFlow.fs
+++ b/src/MBrace.Flow/CloudFlow.fs
@@ -676,7 +676,7 @@ module CloudFlow =
             return vc
         }
 
-    /// <summary>Creates a CloudVector from the given CloudFlow, with its partitions cached localy</summary>
+    /// <summary>Creates a CloudVector from the given CloudFlow, with its partitions cached locally</summary>
     /// <param name="flow">The input CloudFlow.</param>
     /// <returns>The result CloudVector.</returns>
     let inline toCachedCloudVector (flow : CloudFlow<'T>) : Cloud<CloudVector<'T>> =

--- a/src/MBrace.Flow/CloudFlow.fs
+++ b/src/MBrace.Flow/CloudFlow.fs
@@ -73,7 +73,8 @@ module CloudFlow =
                         match collector.DegreeOfParallelism with
                         | Some n -> local { return n }
                         | _ -> Cloud.GetWorkerCount()
-                    let! workers = Cloud.GetAvailableWorkers()
+                    let! workers = Cloud.GetAvailableWorkers() 
+                    let workers = workers |> Array.sortBy (fun workerRef -> workerRef.Id)
 
                     let createTask array (collector : Local<Collector<'T, 'S>>) = 
                         local {
@@ -121,6 +122,7 @@ module CloudFlow =
                             | Some n -> local { return n }
                             | _ -> Cloud.GetWorkerCount()
                         let! workers = Cloud.GetAvailableWorkers() 
+                        let workers = workers |> Array.sortBy (fun workerRef -> workerRef.Id)
 
                         let createTask (files : CloudFile []) (collectorf : Local<Collector<'T, 'S>>) : Local<'R> = 
                             local {
@@ -218,6 +220,7 @@ module CloudFlow =
                             | None -> return! Cloud.GetWorkerCount()
                         }
                         let! workers = Cloud.GetAvailableWorkers()
+                        let workers = workers |> Array.sortBy (fun workerRef -> workerRef.Id)
 
                         // TODO : need a scheduling algorithm to assign partition indices
                         //        to workers according to current cache state.
@@ -1044,6 +1047,7 @@ module CloudFlow =
                         | Some n -> local { return n }
                         | _ -> Cloud.GetWorkerCount()
                     let! workers = Cloud.GetAvailableWorkers()
+                    let workers = workers |> Array.sortBy (fun workerRef -> workerRef.Id)
 
                     let rangeBasedReadLines (s : int64) (e : int64) (flow : System.IO.Stream) = 
                         seq {

--- a/tests/MBrace.Flow.Tests/CloudFlowTests.fs
+++ b/tests/MBrace.Flow.Tests/CloudFlowTests.fs
@@ -10,6 +10,7 @@ open NUnit.Framework
 open MBrace.Flow
 open MBrace
 open MBrace.Store
+open System.Text
 
 [<TestFixture; AbstractClass>]
 type ``CloudFlow tests`` () as self =
@@ -154,6 +155,16 @@ type ``CloudFlow tests`` () as self =
             let x = xs |> CloudFlow.ofArray |> CloudFlow.map ((+)1) |> CloudFlow.toCloudVector |> run
             let y = xs |> Seq.map ((+)1) |> Seq.toArray
             Assert.AreEqual(y, cloud { return! x.ToEnumerable() } |> runLocal)
+        Check.QuickThrowOnFail(f, self.FsCheckMaxNumberOfTests)
+
+
+    [<Test>]
+    member __.``2. CloudFlow : toCachedCloudVector`` () =
+        let f(xs : string[]) =            
+            let cv = xs |> CloudFlow.ofArray |> CloudFlow.map (fun x -> new StringBuilder(x)) |> CloudFlow.toCachedCloudVector |> run
+            let x = cv |> CloudFlow.ofCloudVector |> CloudFlow.map (fun sb -> sb.GetHashCode()) |> CloudFlow.toArray |> run
+            let y = cv |> CloudFlow.ofCloudVector |> CloudFlow.map (fun sb -> sb.GetHashCode()) |> CloudFlow.toArray |> run
+            Assert.AreEqual(x, y)
         Check.QuickThrowOnFail(f, self.FsCheckMaxNumberOfTests)
 
     [<Test>]


### PR DESCRIPTION
This PR implements a new terminal combinator ClouFlow.toCachedCloudVector which is similar to toCloudVector but also caches its partitions locally.