### PR TITLE
namespace MBrace --> MBrace.Core

### DIFF
--- a/samples/MBrace.Flow.Samples/wordcount.fsx
+++ b/samples/MBrace.Flow.Samples/wordcount.fsx
@@ -8,7 +8,7 @@ open System
 open System.IO
 open System.Text.RegularExpressions
 open Nessos.Streams
-open MBrace
+open MBrace.Core
 open MBrace.SampleRuntime
 open MBrace.Flow
 

--- a/samples/MBrace.SampleRuntime/Actors.fs
+++ b/samples/MBrace.SampleRuntime/Actors.fs
@@ -18,7 +18,7 @@ open Nessos.Vagabond
 open Nessos.Vagabond.AssemblyProtocols
 open Nessos.Vagabond.ExportableAssembly
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Runtime
 open MBrace.Runtime.Utils

--- a/samples/MBrace.SampleRuntime/Client.fs
+++ b/samples/MBrace.SampleRuntime/Client.fs
@@ -7,7 +7,7 @@ open System.Threading
 open Nessos.Thespian
 open Nessos.Thespian.Remote
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Client
 open MBrace.Continuation

--- a/samples/MBrace.SampleRuntime/Combinators.fs
+++ b/samples/MBrace.SampleRuntime/Combinators.fs
@@ -4,7 +4,7 @@
 //  Provides distributed implementations for Cloud.Parallel, Cloud.Choice and Cloud.StartChild
 //
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Runtime
 open MBrace.Runtime.Utils

--- a/samples/MBrace.SampleRuntime/DistributionProvider.fs
+++ b/samples/MBrace.SampleRuntime/DistributionProvider.fs
@@ -14,7 +14,7 @@ open Nessos.Thespian.Remote
 
 open Nessos.Vagabond
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Workflows
 open MBrace.Runtime.InMemory

--- a/samples/MBrace.SampleRuntime/Types.fs
+++ b/samples/MBrace.SampleRuntime/Types.fs
@@ -13,7 +13,7 @@ open System
 open Nessos.FsPickler
 open Nessos.Vagabond
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Store
 

--- a/samples/MBrace.SampleRuntime/test.fsx
+++ b/samples/MBrace.SampleRuntime/test.fsx
@@ -4,7 +4,7 @@
 #r "MBrace.SampleRuntime.exe"
 
 open System
-open MBrace
+open MBrace.Core
 open MBrace.Workflows
 open MBrace.SampleRuntime
 

--- a/src/MBrace.Core/Client/LocalRuntime.fs
+++ b/src/MBrace.Core/Client/LocalRuntime.fs
@@ -2,7 +2,7 @@
 
 open System.Threading
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Store
 open MBrace.Runtime

--- a/src/MBrace.Core/Client/StoreClient.fs
+++ b/src/MBrace.Core/Client/StoreClient.fs
@@ -5,7 +5,7 @@
 open System.IO
 open System.Text
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Continuation
 open MBrace.Runtime.InMemory

--- a/src/MBrace.Core/Continuation/Builders.fs
+++ b/src/MBrace.Core/Continuation/Builders.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 //  Cloud builder implementation
 

--- a/src/MBrace.Core/Continuation/CancellationToken.fs
+++ b/src/MBrace.Core/Continuation/CancellationToken.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System.Threading
 

--- a/src/MBrace.Core/Continuation/Cloud.fs
+++ b/src/MBrace.Core/Continuation/Cloud.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System.Runtime.Serialization
 

--- a/src/MBrace.Core/Continuation/Continuation.fs
+++ b/src/MBrace.Core/Continuation/Continuation.fs
@@ -3,7 +3,7 @@
 open System.Threading
 open System.Threading.Tasks
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 
 #nowarn "444"

--- a/src/MBrace.Core/Continuation/ExecutionContext.fs
+++ b/src/MBrace.Core/Continuation/ExecutionContext.fs
@@ -3,7 +3,7 @@
 open System
 open System.Threading
 
-open MBrace
+open MBrace.Core
 
 /// Local, non-distributable continuation execution context.
 [<AutoSerializable(false)>]

--- a/src/MBrace.Core/Continuation/Utils.fs
+++ b/src/MBrace.Core/Continuation/Utils.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System
 open System.Collections

--- a/src/MBrace.Core/Distribution/Combinators.fs
+++ b/src/MBrace.Core/Distribution/Combinators.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System.Threading.Tasks
 

--- a/src/MBrace.Core/Distribution/DistributionProvider.fs
+++ b/src/MBrace.Core/Distribution/DistributionProvider.fs
@@ -5,7 +5,7 @@
 // be passed an instance of ICloudRuntimeProvider in their
 // ExecutionContext.
 
-open MBrace
+open MBrace.Core
 
 /// <summary>
 ///     Executing runtime abstraction.

--- a/src/MBrace.Core/Distribution/FaultPolicy.fs
+++ b/src/MBrace.Core/Distribution/FaultPolicy.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System
 open System.Runtime.Serialization

--- a/src/MBrace.Core/Distribution/InMemory/InMemoryCombinators.fs
+++ b/src/MBrace.Core/Distribution/InMemory/InMemoryCombinators.fs
@@ -5,7 +5,7 @@
 open System.Threading
 open System.Threading.Tasks
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 
 /// Collection of workflows that provide parallelism

--- a/src/MBrace.Core/Distribution/InMemory/InMemoryRuntime.fs
+++ b/src/MBrace.Core/Distribution/InMemory/InMemoryRuntime.fs
@@ -4,7 +4,7 @@ open System
 open System.Threading
 open System.Threading.Tasks
 
-open MBrace
+open MBrace.Core
 open MBrace.Runtime
 open MBrace.Continuation
 

--- a/src/MBrace.Core/Distribution/InMemory/InMemoryStore.fs
+++ b/src/MBrace.Core/Distribution/InMemory/InMemoryStore.fs
@@ -1,11 +1,9 @@
 ﻿namespace MBrace.Runtime.InMemory
 
-open MBrace
-
 open System
 open System.Threading
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Continuation
 

--- a/src/MBrace.Core/Distribution/RuntimeTypes.fs
+++ b/src/MBrace.Core/Distribution/RuntimeTypes.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System
 open System.Threading

--- a/src/MBrace.Core/Store/Atom.fs
+++ b/src/MBrace.Core/Store/Atom.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open MBrace.Continuation
 
@@ -44,7 +44,7 @@ module CloudAtomUtils =
 
 namespace MBrace.Store
  
-open MBrace
+open MBrace.Core
 
 /// Defines a factory for distributed atoms
 type ICloudAtomProvider =
@@ -98,7 +98,7 @@ with
         }
 
 
-namespace MBrace
+namespace MBrace.Core
 
 open MBrace.Continuation
 open MBrace.Store

--- a/src/MBrace.Core/Store/Caching.fs
+++ b/src/MBrace.Core/Store/Caching.fs
@@ -22,7 +22,7 @@ type IObjectCache =
     /// <param name="key"></param>
     abstract TryFind : key:string -> obj option
 
-namespace MBrace
+namespace MBrace.Core
 
 open System
 open System.Runtime.Serialization

--- a/src/MBrace.Core/Store/Cell.fs
+++ b/src/MBrace.Core/Store/Cell.fs
@@ -1,11 +1,11 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System
 open System.Runtime.Serialization
 open System.IO
 open System.Text
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Continuation
 

--- a/src/MBrace.Core/Store/Channel.fs
+++ b/src/MBrace.Core/Store/Channel.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 /// Sending side of a distributed channel
 type ISendPort<'T> =
@@ -27,7 +27,7 @@ type IReceivePort<'T> =
 
 namespace MBrace.Store
 
-open MBrace
+open MBrace.Core
 
 /// Defines a factory for distributed channels
 type ICloudChannelProvider =
@@ -73,7 +73,7 @@ with
             DefaultContainer = match defaultContainer with Some c -> c | None -> channelProvider.CreateUniqueContainerName()
         }
 
-namespace MBrace
+namespace MBrace.Core
 
 open MBrace.Continuation
 open MBrace.Store

--- a/src/MBrace.Core/Store/FileStore.fs
+++ b/src/MBrace.Core/Store/FileStore.fs
@@ -3,7 +3,7 @@
 open System
 open System.IO
 
-open MBrace
+open MBrace.Core
 
 /// Cloud file storage abstraction
 type ICloudFileStore =
@@ -207,7 +207,7 @@ module CloudFileStoreUtils =
             fileNames |> Seq.map (fun f -> cfs.Combine [|container ; f |]) |> Seq.toArray
 
 
-namespace MBrace
+namespace MBrace.Core
 
 open System
 open System.Runtime.Serialization

--- a/src/MBrace.Core/Store/Sequence.fs
+++ b/src/MBrace.Core/Store/Sequence.fs
@@ -1,4 +1,4 @@
-﻿namespace MBrace
+﻿namespace MBrace.Core
 
 open System
 open System.Collections

--- a/src/MBrace.Core/Workflows/Common.fs
+++ b/src/MBrace.Core/Workflows/Common.fs
@@ -1,6 +1,6 @@
 ﻿namespace MBrace.Workflows
 
-open MBrace
+open MBrace.Core
 
 [<RequireQualifiedAccess>]
 module Cloud =

--- a/src/MBrace.Core/Workflows/Distributed.fs
+++ b/src/MBrace.Core/Workflows/Distributed.fs
@@ -1,6 +1,6 @@
 ﻿namespace MBrace.Workflows
 
-open MBrace
+open MBrace.Core
 
 /// Collection of combinators that split workloads to workers
 /// according to multicore capacity.

--- a/src/MBrace.Core/Workflows/Sequential.fs
+++ b/src/MBrace.Core/Workflows/Sequential.fs
@@ -1,6 +1,6 @@
 ﻿namespace MBrace.Workflows
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 
 #nowarn "443"

--- a/src/MBrace.Flow/CSharpProxy.fs
+++ b/src/MBrace.Flow/CSharpProxy.fs
@@ -5,7 +5,7 @@ open System.Collections.Generic
 open System.Threading.Tasks
 open Nessos.Streams
 open MBrace.Flow
-open MBrace
+open MBrace.Core
 
 /// [omit]
 /// Proxy for FSharp type specialization and lambda inlining.

--- a/src/MBrace.Flow/CloudFlow.fs
+++ b/src/MBrace.Flow/CloudFlow.fs
@@ -8,7 +8,7 @@ open System.Threading
 open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Linq
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Workflows
 open Nessos.Streams

--- a/src/MBrace.Flow/CloudVector.fs
+++ b/src/MBrace.Flow/CloudVector.fs
@@ -3,7 +3,7 @@
 open System.IO
 open System.Collections.Generic
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Workflows
 

--- a/src/MBrace.Flow/test.fsx
+++ b/src/MBrace.Flow/test.fsx
@@ -4,7 +4,7 @@
 #r "MBrace.SampleRuntime.exe"
 
 open System
-open MBrace
+open MBrace.Core
 open MBrace.SampleRuntime
 
 MBraceRuntime.WorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/MBrace.SampleRuntime.exe"

--- a/src/MBrace.Runtime.Core/Compiler/CloudUtils.fs
+++ b/src/MBrace.Runtime.Core/Compiler/CloudUtils.fs
@@ -8,7 +8,7 @@ open Microsoft.FSharp.Quotations.Patterns
 open Microsoft.FSharp.Quotations.DerivedPatterns
 open Microsoft.FSharp.Quotations.ExprShape
 
-open MBrace
+open MBrace.Core
 open MBrace.Runtime.Utils.Reflection
 
 /// checks if the given type or covariant type arguments are of type Cloud<'T>

--- a/src/MBrace.Runtime.Core/Compiler/Compiler.fs
+++ b/src/MBrace.Runtime.Core/Compiler/Compiler.fs
@@ -12,7 +12,7 @@ open Microsoft.FSharp.Quotations.ExprShape
 open Nessos.FsPickler
 open Nessos.Vagabond
 
-open MBrace
+open MBrace.Core
 
 open MBrace.Runtime
 open MBrace.Runtime.Utils

--- a/src/MBrace.Runtime.Core/Compiler/Types.fs
+++ b/src/MBrace.Runtime.Core/Compiler/Types.fs
@@ -10,7 +10,7 @@ open Microsoft.FSharp.Quotations.Patterns
 open Nessos.Vagabond
 open Nessos.FsPickler
 
-open MBrace
+open MBrace.Core
 open MBrace.Runtime.Utils.PrettyPrinters
 open MBrace.Runtime.Vagabond
 open MBrace.Runtime.Serialization

--- a/src/MBrace.Runtime.Core/Store/FileStoreCache.fs
+++ b/src/MBrace.Runtime.Core/Store/FileStoreCache.fs
@@ -6,7 +6,7 @@ open System.Collections.Generic
 open System.Collections.Concurrent
 open System.Runtime.Serialization
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Runtime.Utils
 open MBrace.Runtime.Utils.String

--- a/src/MBrace.Runtime.Core/Store/FileSystemStore.fs
+++ b/src/MBrace.Runtime.Core/Store/FileSystemStore.fs
@@ -5,7 +5,7 @@ open System.IO
 open System.Security.AccessControl
 open System.Runtime.Serialization
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Store
 open MBrace.Runtime

--- a/tests/MBrace.Core.Tests/ContinuationTests.fs
+++ b/tests/MBrace.Core.Tests/ContinuationTests.fs
@@ -5,7 +5,7 @@ open System.Threading
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Workflows
 open MBrace.Client
@@ -481,11 +481,11 @@ module ``Continuation Tests`` =
 
     [<Test>]
     let ``runtime resources`` () =
-        run(Cloud.GetWorkerCount()) |> Choice.shouldFailwith<_, Continuation.ResourceNotFoundException>
+        run(Cloud.GetWorkerCount()) |> Choice.shouldFailwith<_, MBrace.Continuation.ResourceNotFoundException>
 
     [<Test>]
     let ``storage resouces`` () =
-        run(CloudCell.New 0) |> Choice.shouldFailwith<_, Continuation.ResourceNotFoundException>
+        run(CloudCell.New 0) |> Choice.shouldFailwith<_, MBrace.Continuation.ResourceNotFoundException>
 
     [<Test>]
     let ``test correct scoping in resource updates`` () =

--- a/tests/MBrace.Core.Tests/InMemoryTests.fs
+++ b/tests/MBrace.Core.Tests/InMemoryTests.fs
@@ -2,7 +2,7 @@
 
 open System.Threading
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Runtime
 open MBrace.Client

--- a/tests/MBrace.Core.Tests/ParallelismTests.fs
+++ b/tests/MBrace.Core.Tests/ParallelismTests.fs
@@ -5,7 +5,7 @@ open System.Threading
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Workflows
 open MBrace.Runtime.InMemory

--- a/tests/MBrace.Core.Tests/StoreTests/CloudAtomTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/CloudAtomTests.fs
@@ -4,7 +4,7 @@ open System
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Client
 

--- a/tests/MBrace.Core.Tests/StoreTests/CloudChannelTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/CloudChannelTests.fs
@@ -2,7 +2,7 @@
 
 open System
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Workflows
 open MBrace.Client

--- a/tests/MBrace.Core.Tests/StoreTests/FileStoreTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/FileStoreTests.fs
@@ -5,7 +5,7 @@ open System.IO
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Workflows
 open MBrace.Store

--- a/tests/MBrace.Core.Tests/TestTypes.fs
+++ b/tests/MBrace.Core.Tests/TestTypes.fs
@@ -2,7 +2,7 @@
 
 open System.Collections.Generic
 
-open MBrace
+open MBrace.Core
 open MBrace.Workflows
 
 type DummyDisposable() =

--- a/tests/MBrace.Flow.Tests/CloudFlowTests.fs
+++ b/tests/MBrace.Flow.Tests/CloudFlowTests.fs
@@ -8,7 +8,7 @@ open System.IO
 open FsCheck
 open NUnit.Framework
 open MBrace.Flow
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open System.Text
 

--- a/tests/MBrace.Runtime.Core.Tests/Compiler.fs
+++ b/tests/MBrace.Runtime.Core.Tests/Compiler.fs
@@ -1,6 +1,6 @@
 ﻿namespace MBrace.Runtime.Tests
 
-open MBrace
+open MBrace.Core
 open MBrace.Runtime.Vagabond
 open MBrace.Runtime.Compiler
 open MBrace.Tests

--- a/tests/MBrace.Runtime.Core.Tests/FileSystemStore.fs
+++ b/tests/MBrace.Runtime.Core.Tests/FileSystemStore.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Runtime.InMemory
 open MBrace.Runtime.Vagabond
 open MBrace.Runtime.Serialization

--- a/tests/MBrace.Runtime.Core.Tests/InMemoryFlowTests.fs
+++ b/tests/MBrace.Runtime.Core.Tests/InMemoryFlowTests.fs
@@ -1,6 +1,6 @@
 ﻿namespace MBrace.Runtime.Tests
 
-open MBrace
+open MBrace.Core
 open MBrace.Store
 open MBrace.Runtime.Vagabond
 open MBrace.Runtime.Serialization

--- a/tests/MBrace.SampleRuntime.Tests/CSharpFlowTestsDriver.fs
+++ b/tests/MBrace.SampleRuntime.Tests/CSharpFlowTestsDriver.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Streams.CSharp.Tests
 
 type ``SampleRuntime CloudStream CSharp Tests`` () =

--- a/tests/MBrace.SampleRuntime.Tests/CSharpTestsDriver.fs
+++ b/tests/MBrace.SampleRuntime.Tests/CSharpTestsDriver.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.CSharp.Tests
 
 type ``SampleRuntime CSharp Tests`` () =

--- a/tests/MBrace.SampleRuntime.Tests/FlowTests.fs
+++ b/tests/MBrace.SampleRuntime.Tests/FlowTests.fs
@@ -4,7 +4,7 @@ open System.IO
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Flow.Tests
 open MBrace.SampleRuntime
 

--- a/tests/MBrace.SampleRuntime.Tests/ParallelismTests.fs
+++ b/tests/MBrace.SampleRuntime.Tests/ParallelismTests.fs
@@ -6,7 +6,7 @@ open System.Threading
 
 open NUnit.Framework
 
-open MBrace
+open MBrace.Core
 open MBrace.Continuation
 open MBrace.Workflows
 open MBrace.Runtime

--- a/tests/MBrace.SampleRuntime.Tests/StoreTests.fs
+++ b/tests/MBrace.SampleRuntime.Tests/StoreTests.fs
@@ -2,7 +2,7 @@
 
 open System.Threading
 
-open MBrace
+open MBrace.Core
 open MBrace.Tests
 open MBrace.SampleRuntime
 


### PR DESCRIPTION
I suggest everything immediately under "MBrace" should go into "MBrace.Core".   .NET programmmers minimally expect a clean two-level namespace structure like this.
