### PR TITLE
Rewrite cloud collection partitioning

### DIFF
--- a/src/MBrace.Core/Library/CollectionPartitioner.fs
+++ b/src/MBrace.Core/Library/CollectionPartitioner.fs
@@ -29,7 +29,7 @@ type CloudCollection private () =
 
     static member ExtractPartitions (collection : ICloudCollection<'T>) : Local<ICloudCollection<'T> []> = CloudCollection.ExtractPartitions([|collection|])
 
-    static member PartitionBySize (workers : IWorkerRef [],  isTargetedWorkerEnabled : bool, collections : ICloudCollection<'T> []) = local {
+    static member PartitionBySize (workers : IWorkerRef [], isTargetedWorkerEnabled : bool, collections : ICloudCollection<'T> []) = local {
         let isSizeKnown = collections |> Array.forall (fun c -> c.IsKnownSize)
         if not isSizeKnown then
             if isTargetedWorkerEnabled then

--- a/src/MBrace.Core/Library/CollectionPartitioner.fs
+++ b/src/MBrace.Core/Library/CollectionPartitioner.fs
@@ -1,0 +1,94 @@
+﻿namespace MBrace.Store.Internals
+
+open MBrace.Core
+open MBrace.Core.Internals
+open MBrace.Store
+open MBrace.Workflows
+
+type CloudCollection private () =
+
+    static member ExtractPartitions (collections : seq<ICloudCollection<'T>>) : Local<ICloudCollection<'T> []> = local {
+        let rec extractCollection (c : ICloudCollection<'T>) = 
+            local {
+                match c with
+                | :? IPartitionedCollection<'T> as c ->
+                    let! partitions = c.GetPartitions()
+                    return! extractCollections partitions
+                | c -> return Seq.singleton c
+            }
+
+        and extractCollections (cs : seq<ICloudCollection<'T>>) =
+            local {
+                let! extracted = cs |> Sequential.map extractCollection
+                return Seq.concat extracted
+            }
+
+        let! extracted = extractCollections collections
+        return Seq.toArray extracted
+    }
+
+    static member ExtractPartitions (collection : ICloudCollection<'T>) : Local<ICloudCollection<'T> []> = CloudCollection.ExtractPartitions([|collection|])
+
+    static member PartitionBySize (workers : IWorkerRef [],  isTargetedWorkerEnabled : bool, collections : ICloudCollection<'T> []) = local {
+        let isSizeKnown = collections |> Array.forall (fun c -> c.IsKnownSize)
+        if not isSizeKnown then
+            if isTargetedWorkerEnabled then
+                return WorkerRef.partitionWeighted (fun w -> w.ProcessorCount) workers collections
+            else
+                return WorkerRef.partition workers collections
+        else
+
+        let! sizes = collections |> Sequential.map (fun c -> c.Size)
+        let totalSize = Array.sum sizes
+        let coreCount = workers |> Array.sumBy (fun w -> if isTargetedWorkerEnabled then w.ProcessorCount else 1)
+        let sizePerCore = totalSize / int64 coreCount
+        let sizesPerWorker = [| for w in workers -> if isTargetedWorkerEnabled then sizePerCore else int64 w.ProcessorCount * sizePerCore |]
+
+        let rec aux acc accWorker (accWorkerSize : int64) (workerIndex : int) (collectionSlices : (int * int64) list) (collectionIndex : int) = local {
+            let mkPartition i (collected : ICloudCollection<'T> list) = workers.[i], collected |> List.rev |> List.toArray
+            if collectionIndex = collections.Length then 
+                match accWorker with
+                | [] -> return acc |> List.rev |> List.toArray
+                | _ -> return mkPartition workerIndex accWorker :: acc |> List.rev |> List.toArray
+            else
+                match [], collections.[collectionIndex] with
+                | [], collection when accWorkerSize + sizes.[collectionIndex] <= sizesPerWorker.[workerIndex] ->
+                    return! aux acc (collection :: accWorker) (accWorkerSize + sizes.[collectionIndex]) workerIndex [] (collectionIndex + 1)
+
+                | _, (:? IPartitionableCollection<'T> as pc) ->
+                    let usedBytes = collectionSlices |> List.sumBy snd
+                    let remainingBytes = sizes.[collectionIndex] - usedBytes
+                    if accWorkerSize + remainingBytes <= sizesPerWorker.[workerIndex] then
+                        let slices = (workerIndex, remainingBytes) :: collectionSlices |> List.rev |> List.toArray
+                        let weights = slices |> Array.map snd |> Array.gcdNormalize |> Array.map int
+                        let! partitions = pc.GetPartitions weights
+                        assert(weights.Length > 1 && partitions.Length = weights.Length)
+                        let accPartitions =
+                            [
+                                yield mkPartition (fst slices.[0]) (partitions.[0] :: accWorker)
+                                for i in 1 .. partitions.Length - 1 -> mkPartition (fst slices.[i]) [partitions.[i]]
+                            ]
+
+                        let accWorker = [partitions.[partitions.Length - 1]]
+                        return! aux (List.rev accPartitions @ acc) accWorker (accWorkerSize + remainingBytes) workerIndex [] (collectionIndex + 1)
+                    else
+                        let partitionSize = sizesPerWorker.[workerIndex] - accWorkerSize
+                        return! aux acc accWorker 0L (workerIndex + 1) ((workerIndex, partitionSize) :: collectionSlices) collectionIndex
+
+                | [], collection ->
+                    // include if remaining capacity is more than half the partition size
+                    if (sizesPerWorker.[workerIndex] - accWorkerSize) * 2L > sizes.[collectionIndex] then
+                        let partitions = mkPartition workerIndex (collection :: accWorker)
+                        return! aux (partitions :: acc) [] 0L (workerIndex + 1) [] (collectionIndex + 1)
+                    elif workerIndex = workers.Length - 1 then
+                        let remainingPartitions = collections.[collectionIndex ..] |> Array.toList |> List.rev
+                        return! aux acc (remainingPartitions @ accWorker) 0L workerIndex [] collections.Length
+                    else
+                        let partitions = mkPartition workerIndex accWorker
+                        return! aux (partitions :: acc) [] 0L (workerIndex + 1)  [] collectionIndex
+
+                | state -> return invalidOp "internal error %A." state
+        }
+
+        return! aux [] [] 0L 0 [] 0
+    }

--- a/src/MBrace.Core/Library/CollectionPartitioner.fs
+++ b/src/MBrace.Core/Library/CollectionPartitioner.fs
@@ -30,6 +30,7 @@ type CloudCollection private () =
     static member ExtractPartitions (collection : ICloudCollection<'T>) : Local<ICloudCollection<'T> []> = CloudCollection.ExtractPartitions([|collection|])
 
     static member PartitionBySize (workers : IWorkerRef [], isTargetedWorkerEnabled : bool, collections : ICloudCollection<'T> []) = local {
+        if workers.Length = 0 then return invalidArg "workers" "must be non-empty."
         let isSizeKnown = collections |> Array.forall (fun c -> c.IsKnownSize)
         if not isSizeKnown then
             if isTargetedWorkerEnabled then

--- a/src/MBrace.Core/Library/CollectionPartitioner.fs
+++ b/src/MBrace.Core/Library/CollectionPartitioner.fs
@@ -1,5 +1,7 @@
 ﻿namespace MBrace.Store.Internals
 
+open System
+
 open MBrace.Core
 open MBrace.Core.Internals
 open MBrace.Store
@@ -38,59 +40,100 @@ type CloudCollection private () =
             else
                 return WorkerRef.partition workers collections
         else
+            
+        let rec aux (accPartitions : (IWorkerRef * ICloudCollection<'T> []) list) 
+                    (currWorker : IWorkerRef) (remWorkerSize : int64) (accWorkerCollections : ICloudCollection<'T> list)
+                    (remWorkers : (IWorkerRef * int64) list) (remCollections : (ICloudCollection<'T> * int64) list) = local {
 
-        let! sizes = collections |> Sequential.map (fun c -> c.Size)
-        let totalSize = Array.sum sizes
-        let coreCount = workers |> Array.sumBy (fun w -> if isTargetedWorkerEnabled then w.ProcessorCount else 1)
-        let sizePerCore = totalSize / int64 coreCount
-        let sizesPerWorker = [| for w in workers -> if isTargetedWorkerEnabled then int64 w.ProcessorCount * sizePerCore else sizePerCore |]
+            let mkPartition worker (acc : ICloudCollection<'T> list) = worker, acc |> List.rev |> List.toArray
 
-        let rec aux acc accWorker (accWorkerSize : int64) (workerIndex : int) (collectionSlices : (int * int64) list) (collectionIndex : int) = local {
-            let mkPartition i (collected : ICloudCollection<'T> list) = workers.[i], collected |> List.rev |> List.toArray
-            if collectionIndex = collections.Length then 
-                match accWorker with
-                | [] -> return acc |> List.rev |> List.toArray
-                | _ -> return mkPartition workerIndex accWorker :: acc |> List.rev |> List.toArray
+            match remWorkers, accWorkerCollections, remCollections with
+            // remaining collection set exhausted, return accumulated partitions with empty sets for remaining workers.
+            | _, _, [] ->
+                return [|
+                    yield! List.rev accPartitions
+                    yield mkPartition currWorker accWorkerCollections
+                    for rw,_ in remWorkers -> (rw, [||]) |]
 
-            elif workerIndex = workers.Length - 1 then
-                let remainingPartitions = collections.[collectionIndex ..] |> Array.toList |> List.rev
-                return! aux acc (remainingPartitions @ accWorker) 0L workerIndex [] collections.Length
-            else
-                match collectionSlices, collections.[collectionIndex] with
-                | [], collection when accWorkerSize + sizes.[collectionIndex] <= sizesPerWorker.[workerIndex] ->
-                    return! aux acc (collection :: accWorker) (accWorkerSize + sizes.[collectionIndex]) workerIndex [] (collectionIndex + 1)
+            // remaining worker set exhausted, shoehorn all remaining collections to the current worker.
+            | [], awc, rcs -> 
+                let rcs = rcs |> List.map fst |> List.rev
+                return! aux accPartitions currWorker 0L (rcs @ awc) [] []
 
-                | _, (:? IPartitionableCollection<'T> as pc) ->
-                    let usedBytes = collectionSlices |> List.sumBy snd
-                    let remainingBytes = sizes.[collectionIndex] - usedBytes
-                    if accWorkerSize + remainingBytes <= sizesPerWorker.[workerIndex] then
-                        let slices = (workerIndex, remainingBytes) :: collectionSlices |> List.rev |> List.toArray
-                        let weights = slices |> Array.map snd |> Array.gcdNormalize |> Array.map int
-                        let! partitions = pc.GetPartitions weights
-                        assert(weights.Length > 1 && partitions.Length = weights.Length)
-                        let accPartitions =
-                            [
-                                yield mkPartition (fst slices.[0]) (partitions.[0] :: accWorker)
-                                for i in 1 .. partitions.Length - 1 -> mkPartition (fst slices.[i]) [partitions.[i]]
-                            ]
+            // next collection is withing remaining worker size, include to accumulated collections and update size.
+            | _, _, (c, csz) :: rc when csz <= remWorkerSize -> 
+                return! aux accPartitions currWorker (remWorkerSize - csz) (c :: accWorkerCollections) remWorkers rc
 
-                        let accWorker = [partitions.[partitions.Length - 1]]
-                        return! aux (List.rev accPartitions @ acc) accWorker (accWorkerSize + remainingBytes) workerIndex [] (collectionIndex + 1)
+            // next collection is partitionable that does not fit in current worker, begin dynamic partitioning logic.
+            | _, _, (:? IPartitionableCollection<'T> as pc, csz) :: rc ->
+                // traverse remaining workers, computing size of partitionable allocated to each of them.
+                let rec getSizes (acc : (IWorkerRef * int64) list) (workers : (IWorkerRef * int64) list) (remSize : int64) =
+                    if remSize <= 0L then List.rev acc, workers else
+
+                    match workers with
+                    | [] -> failwith "CloudCollection.PartitionBySize: internal error."
+                    | (w, wsize) :: rest when wsize > remSize -> getSizes ((w, remSize) :: acc) ((w, wsize - remSize) :: rest) 0L
+                    | (_, wsize) as w :: rest -> getSizes (w :: acc) rest (remSize - wsize)
+
+                let sizes, remWorkers2 = getSizes [] ((currWorker, remWorkerSize) :: remWorkers) csz
+
+                // compute partition weights based on calculated worker sizes
+                let weights =
+                    let sizes = sizes |> Seq.map snd |> Seq.toArray
+                    let gcdNormalized = Array.gcdNormalize sizes
+                    let max = Array.max gcdNormalized
+                    if max <= int64 Int32.MaxValue then gcdNormalized |> Array.map int
                     else
-                        let partitionSize = sizesPerWorker.[workerIndex] - accWorkerSize
-                        return! aux acc accWorker 0L (workerIndex + 1) ((workerIndex, partitionSize) :: collectionSlices) collectionIndex
+                        let min = gcdNormalized |> Array.min |> decimal
+                        [| for s in gcdNormalized -> (decimal s / min) |> round |> int |]
 
-                | [], collection ->
-                    // include if remaining capacity is more than half the partition size
-                    if (sizesPerWorker.[workerIndex] - accWorkerSize) * 2L > sizes.[collectionIndex] then
-                        let partitions = mkPartition workerIndex (collection :: accWorker)
-                        return! aux (partitions :: acc) [] 0L (workerIndex + 1) [] (collectionIndex + 1)
-                    else
-                        let partitions = mkPartition workerIndex accWorker
-                        return! aux (partitions :: acc) [] 0L (workerIndex + 1)  [] collectionIndex
+                // extract partitions based on weights
+                let! cpartitions = pc.GetPartitions weights
 
-                | state -> return invalidOp "internal error %A." state
+                // Partition array should contain at least 2 elements:
+                // * the first partition is assigned to the current worker.
+                // * the last partition will be included in the accumulator state at the tail call.
+                // * intermediate partitions, if they exist, will be included as standalone collections
+                //   in their assigned workers .
+
+                let firstPartition = mkPartition currWorker (cpartitions.[0] :: accWorkerCollections)
+                let lastPartition = cpartitions.[cpartitions.Length - 1]
+                let intermediatePartitions =
+                    [
+                        for i = 1 to cpartitions.Length - 2 do
+                            let w,_ = remWorkers.[i - 1] 
+                            yield (w, [| cpartitions.[i] |])
+                    ]
+                
+                let newCurrWorker, newCurrSize = remWorkers.[cpartitions.Length - 2]
+                return! aux (List.rev (firstPartition :: intermediatePartitions) @ accPartitions) newCurrWorker newCurrSize [lastPartition] remWorkers2 rc
+
+            // include if remaining capacity is more than half the partition size
+            | (w, wsz) :: rw, _, (c, csz) :: rc when remWorkerSize * 2L > csz ->
+                let partition = mkPartition currWorker (c :: accWorkerCollections)
+                return! aux (partition :: accPartitions) w wsz [] rw rc
+            // move partition to next worker otherwise
+            | (w, wsz) :: rw, _, _ ->
+                let partition = mkPartition currWorker accWorkerCollections
+                return! aux (partition :: accPartitions) w wsz [] rw remCollections
         }
 
-        return! aux [] [] 0L 0 [] 0
+        let! wsizes = collections |> Sequential.map (fun c -> local { let! sz = c.Size in return c, sz })
+        let totalSize = wsizes |> Array.sumBy snd
+        let coreCount = workers |> Array.sumBy (fun w -> if isTargetedWorkerEnabled then w.ProcessorCount else 1)
+        let sizePerCore = totalSize / int64 coreCount
+        let rem = ref <| totalSize % int64 coreCount
+        let workers = 
+            [
+                for w in workers do
+                    let deg = if isTargetedWorkerEnabled then int64 w.ProcessorCount else 1L
+                    let r = min deg !rem
+                    rem := !rem - r
+                    let size = deg * sizePerCore + r
+                    yield (w, size)
+            ]
+
+        match workers with
+        | [] -> return invalidArg "workers" "Should be non-empty collection."
+        | (hWorker, hSize) :: tailW -> return! aux [] hWorker hSize [] tailW (Array.toList wsizes)
     }

--- a/src/MBrace.Core/MBrace.Core.fsproj
+++ b/src/MBrace.Core/MBrace.Core.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="Library\Distributed.fs" />
     <Compile Include="Library\CloudValue.fs" />
     <Compile Include="Library\CloudSequence.fs" />
+    <Compile Include="Library\CollectionPartitioner.fs" />
     <Compile Include="Client\StoreClient.fs" />
     <Compile Include="Client\LocalRuntime.fs" />
   </ItemGroup>

--- a/src/MBrace.Core/Store/CloudCollection.fs
+++ b/src/MBrace.Core/Store/CloudCollection.fs
@@ -43,8 +43,9 @@ type IPartitionedCollection<'T> =
 /// A cloud collection that can be partitioned into smaller collections of provided size.
 type IPartitionableCollection<'T> =
     inherit ICloudCollection<'T>
-    /// Partitions the collection into collections of given count
-    abstract GetPartitions : partitionCount:int -> Local<ICloudCollection<'T> []>
+//    /// Partitions the collection into collections of given count
+//    abstract GetPartitions : partitionCount:int -> Local<ICloudCollection<'T> []>
+    abstract GetPartitions : weights:int[] -> Local<ICloudCollection<'T> []>
 
 
 [<AutoOpen>]

--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -94,7 +94,7 @@ module Utils =
         /// <param name="lower">Lower bound of range.</param>
         /// <param name="upper">Upper bound of range.</param>
         let splitWeightedRange (weights : int []) (lower : int64) (upper : int64) : (int64 * int64) option [] =
-            if lower > upper then raise <| new ArgumentOutOfRangeException()
+            if lower > upper then Array.init weights.Length (fun _ -> None)
             elif weights.Length = 0 then invalidArg "weights" "must be non-empty array."
             else
 

--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -143,6 +143,21 @@ module Utils =
                 |> Array.map (function None -> [||] | Some (s,e) -> input.[int s .. int e])
 
 
+        /// computes the gcd for a collection of integers
+        let inline gcd (inputs : 't []) : 't =
+            let rec gcd m n =
+                if n > m then gcd n m
+                elif n = LanguagePrimitives.GenericZero then m
+                else gcd n (m % n)
+
+            Array.fold gcd LanguagePrimitives.GenericZero inputs
+
+        /// normalize a collection of inputs w.r.t. gcd
+        let inline gcdNormalize (inputs : 't []) : 't [] =
+            let gcd = gcd inputs
+            inputs |> Array.map (fun i -> i / gcd)
+
+
     module Seq =
         let fromEnumerator (enum : unit -> IEnumerator<'T>) =
             { new IEnumerable<'T> with

--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -39,9 +39,9 @@ module Utils =
             else
 
             let length = endRange - startRange
-            if length = 0L then [||] else
+            if length = 0L then Array.init partitions (fun _ -> (startRange + 1L, startRange)) else
 
-            let partitions = if length < int64 partitions then length else int64 partitions
+            let partitions = int64 partitions
             let chunkSize = length / partitions
             let r = length % partitions
             let ranges = new ResizeArray<int64 * int64>()

--- a/src/MBrace.Flow/Producers/CloudCollection.fs
+++ b/src/MBrace.Flow/Producers/CloudCollection.fs
@@ -38,7 +38,7 @@ type internal CloudCollection private () =
                     | Some dp -> [| for i in 0 .. dp - 1 -> workers.[i % workers.Length] |]
 
                 let! partitions = CloudCollection.ExtractPartitions collection
-                let! partitionss = CloudCollection.PartitionBySize(workers, isTargetedWorkerSupported, partitions)
+                let! partitionss = CloudCollection.PartitionBySize(partitions, workers, isTargetedWorkerSupported)
                 if Array.isEmpty partitionss then return! combiner [||] else
 
                 // use caching, if supported by collection

--- a/src/MBrace.Flow/Producers/CloudCollection.fs
+++ b/src/MBrace.Flow/Producers/CloudCollection.fs
@@ -16,29 +16,6 @@ open MBrace.Flow.Internals
 
 type internal CloudCollection private () =
 
-    static let rec extractPartitions (c : ICloudCollection<'T>) = local {
-        match c with
-        | :? IPartitionedCollection<'T> as c ->
-            let! partitions = c.GetPartitions()
-            let! extracted = partitions |> Sequential.map extractPartitions
-            return Seq.concat extracted
-        | c -> return Seq.singleton c
-    }
-
-    static let (|Partitionable|_|) (collections : ICloudCollection<'T> []) =
-        let partitionables = collections |> Array.choose (function :? IPartitionableCollection<'T> as pc -> Some pc | _ -> None)
-        if partitionables.Length = collections.Length then Some partitionables
-        else None
-
-    static let computeSizes (collections : ICloudCollection<'T> []) = local {
-        let isSizeKnown = collections |> Array.forall (fun p -> p.IsKnownSize)
-        if isSizeKnown then
-            let! sizes = collections |> Sequential.map (fun p -> p.Size)
-            return Some sizes
-        else
-            return None
-    }
-
     /// <summary>
     ///     Creates a CloudFlow according to partitions of provided cloud collection.
     /// </summary>
@@ -49,117 +26,75 @@ type internal CloudCollection private () =
         let useCache = defaultArg useCache false
         { new CloudFlow<'T> with
             member self.DegreeOfParallelism = None
-            member self.WithEvaluators<'S, 'R> (collectorf : Local<Collector<'T, 'S>>) (projection : 'S -> Local<'R>) (combiner : 'R [] -> Local<'R>) =
-                cloud {
-                    // TODO: 
-                    //   1. take nested partitioning into account
-                    //   2. partition according to collection sizes; current partition schemes assume that inputs are homogeneous
-                    //      but this might not be the case.
-                    let! collector = collectorf
-                    let! targetedworkerSupport = Cloud.IsTargetedWorkerSupported
-                    let! workers = Cloud.GetAvailableWorkers()
-                    // sort by id to ensure deterministic scheduling
-                    let workers = workers |> Array.sortBy (fun w -> w.Id)
-                    let workers =
-                        match collector.DegreeOfParallelism with
-                        | None -> workers
-                        | Some dp -> [| for i in 0 .. dp - 1 -> workers.[i % workers.Length] |]
+            member self.WithEvaluators<'S, 'R> (collectorf : Local<Collector<'T, 'S>>) (projection : 'S -> Local<'R>) (combiner : 'R [] -> Local<'R>) = cloud {
+                let! collector = collectorf
+                let! isTargetedWorkerSupported = Cloud.IsTargetedWorkerSupported
+                let! workers = Cloud.GetAvailableWorkers()
+                // sort by id to ensure deterministic scheduling
+                let workers = workers |> Array.sortBy (fun w -> w.Id)
+                let workers =
+                    match collector.DegreeOfParallelism with
+                    | None -> workers
+                    | Some dp -> [| for i in 0 .. dp - 1 -> workers.[i % workers.Length] |]
 
-                    let! partitions = extractPartitions collection |> Cloud.map Seq.toArray
-                    let! sizes = computeSizes partitions
+                let! partitions = CloudCollection.ExtractPartitions collection
+                let! partitionss = CloudCollection.PartitionBySize(workers, isTargetedWorkerSupported, partitions)
+                if Array.isEmpty partitionss then return! combiner [||] else
 
-                    let! partitions = local {
-                        match partitions, sizes with
-                        | Partitionable partitionables, Some sizes ->
-                            let totalSize = Array.sum sizes
+                // use caching, if supported by collection
+                let tryGetCachedContents (collection : ICloudCollection<'T>) = local {
+                    match box collection with
+                    | :? ICloudCacheable<'T []> as cc -> 
+                        if useCache then 
+                            let! result = CloudCache.GetCachedValue(cc, cacheIfNotExists = true)
+                            return Some result
+                        else 
+                            return! CloudCache.TryGetCachedValue cc
 
-//                    // detect partitions for collection, if any
-//                    let! partitions = local {
-//                        match collection with
-//                        | :? IPartitionedCollection<'T> as pcc -> let! partitions = pcc.GetPartitions() in return Some partitions
-//                        | :? IPartitionableCollection<'T> as pcc ->
-//                            // got a collection that can be partitioned dynamically;
-//                            // partition according core counts per worker
-//                            let partitionCount = workers |> Array.map (fun w -> w.ProcessorCount) |> Array.gcdNormalize |> Array.sum
-//                            let! partitions = pcc.GetPartitions partitionCount 
-//                            return Some partitions
-//
-//                        | _ -> return None
-//                    }
-//
-//                    // use caching, if supported by collection
-//                    let tryGetCachedContents (collection : ICloudCollection<'T>) = local {
-//                        match box collection with
-//                        | :? ICloudCacheable<'T []> as cc -> 
-//                            if useCache then 
-//                                let! result = CloudCache.GetCachedValue(cc, cacheIfNotExists = true)
-//                                return Some result
-//                            else 
-//                                return! CloudCache.TryGetCachedValue cc
-//
-//                        | _ -> return None
-//                    }
-//
-//                    match partitions with
-//                    | None ->
-//                        // no partition scheme, materialize collection in-memory and offload to CloudFlow.ofArray
-//                        let! cached = tryGetCachedContents collection
-//                        let! array = local {
-//                            match cached with
-//                            | Some c -> return c
-//                            | None ->
-//                                let! enum = collection.ToEnumerable()
-//                                return Seq.toArray enum
-//                        }
-//
-//                        let arrayFlow = Array.ToCloudFlow array
-//                        return! arrayFlow.WithEvaluators collectorf projection combiner
-//
-//                    | Some [||] -> return! combiner [||]
-//                    | Some partitions ->
-//                        // have partitions, schedule according to number of partitions.
-//                        let createTask (partitions : ICloudCollection<'T> []) = local {
-//                            // further partition according to collection size threshold, if so specified.
-//                            let! partitionSlices =
-//                                match sizeThresholdPerWorker with
-//                                | None -> local { return [| partitions |] }
-//                                | Some f -> partitions |> Partition.partitionBySize (fun p -> p.Size) (f ())
-//
-//                            // compute a single partition
-//                            let computePartitionSlice (slice : ICloudCollection<'T> []) = local {
-//                                let getSeq (p : ICloudCollection<'T>) = local {
-//                                    let! cached = tryGetCachedContents p
-//                                    match cached with
-//                                    | Some c -> return c :> seq<'T>
-//                                    | None -> return! p.ToEnumerable()
-//                                }
-//
-//                                let! collector = collectorf
-//                                let! seqs = Sequential.map getSeq slice
-//                                let pStream = seqs |> ParStream.ofArray |> ParStream.collect Stream.ofSeq
-//                                let value = pStream.Apply (collector.ToParStreamCollector())
-//                                return! projection value
-//                            }
-//
-//                            // sequentially compute partitions
-//                            let! results = Sequential.map computePartitionSlice partitionSlices
-//                            return! combiner results
-//                        }
-//                        
-//                        let! results =
-//                            if targetedworkerSupport then
-//                                partitions
-//                                |> WorkerRef.partitionWeighted (fun w -> w.ProcessorCount) workers
-//                                |> Seq.filter (not << Array.isEmpty << snd)
-//                                |> Seq.map (fun (w,partitions) -> createTask partitions, w)
-//                                |> Cloud.Parallel
-//                            else
-//                                partitions
-//                                |> WorkerRef.partition workers
-//                                |> Seq.filter (not << Array.isEmpty << snd)
-//                                |> Seq.map (createTask << snd)
-//                                |> Cloud.Parallel
-//
-//                        return! combiner results
-//                }
-//        }
+                    | _ -> return None
+                }
+
+                // have partitions, schedule according to number of partitions.
+                let createTask (partitions : ICloudCollection<'T> []) = local {
+                    // further partition according to collection size threshold, if so specified.
+                    let! partitionSlices =
+                        match sizeThresholdPerWorker with
+                        | None -> local { return [| partitions |] }
+                        | Some f -> partitions |> Partition.partitionBySize (fun p -> p.Size) (f ())
+
+                    // compute a single partition
+                    let computePartitionSlice (slice : ICloudCollection<'T> []) = local {
+                        let getSeq (p : ICloudCollection<'T>) = local {
+                            let! cached = tryGetCachedContents p
+                            match cached with
+                            | Some c -> return c :> seq<'T>
+                            | None -> return! p.ToEnumerable()
+                        }
+
+                        let! collector = collectorf
+                        let! seqs = Sequential.map getSeq slice
+                        let pStream = seqs |> ParStream.ofArray |> ParStream.collect Stream.ofSeq
+                        let value = pStream.Apply (collector.ToParStreamCollector())
+                        return! projection value
+                    }
+
+                    // sequentially compute partitions
+                    let! results = Sequential.map computePartitionSlice partitionSlices
+                    return! combiner results
+                }
+                        
+                let! results =
+                    if isTargetedWorkerSupported then
+                        partitionss
+                        |> Seq.filter (not << Array.isEmpty << snd)
+                        |> Seq.map (fun (w,partitions) -> createTask partitions, w)
+                        |> Cloud.Parallel
+                    else
+                        partitionss
+                        |> Seq.filter (not << Array.isEmpty << snd)
+                        |> Seq.map (createTask << snd)
+                        |> Cloud.Parallel
+
+                return! combiner results
+            }
+        }

--- a/src/MBrace.Flow/Utils.fs
+++ b/src/MBrace.Flow/Utils.fs
@@ -21,21 +21,6 @@ module internal Utils =
                 member self.Iterator() = collector.Iterator()
                 member self.Result = collector.Result }
 
-    module Array =
-        /// computes the gcd for a collection of integers
-        let gcd (inputs : int []) =
-            let rec gcd m n =
-                if n > m then gcd n m
-                elif n = 0 then m
-                else gcd n (m % n)
-
-            Array.fold gcd 0 inputs
-
-        /// normalize a collection of inputs w.r.t. gcd
-        let gcdNormalize (inputs : int []) =
-            let gcd = gcd inputs
-            inputs |> Array.map (fun i -> i / gcd)
-
     module Option =
         /// converts nullable to optional
         let ofNullable (t : Nullable<'T>) =

--- a/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
+++ b/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
@@ -113,7 +113,3 @@ module ``Collection Partitioning Tests`` =
             partitionss |> Array.collect snd |> shouldEqual partitions
 
         Check.QuickThrowOnFail(tester)
-
-    let isTargeted = true
-    let sizes = [|8u; 8u; 16u; 8u|]
-    let workers = 1us

--- a/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
+++ b/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
@@ -147,7 +147,7 @@ module ``Collection Partitioning Tests`` =
             sizes
             |> Seq.map (fun (w,size) -> if isTargeted then size / int64 w.ProcessorCount else size)
             |> variance 
-            |> shouldBe (fun v -> v <= 1.)
+            |> shouldBe (fun v -> v <= 0.5)
 
 
         Check.QuickThrowOnFail(tester, maxRuns = 500)
@@ -166,10 +166,6 @@ module ``Collection Partitioning Tests`` =
             sizes
             |> Seq.map (fun (w,size) -> if isTargeted then size / int64 w.ProcessorCount else size)
             |> variance 
-            |> shouldBe (fun v -> v <= 1.0)
+            |> shouldBe (fun v -> v <= 0.5)
 
         Check.QuickThrowOnFail(tester, maxRuns = 500)
-
-    let isTargeted = false
-    let totalSize = 3L
-    let workerCores = [|0us; 0us; 0us;|]

--- a/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
+++ b/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
@@ -1,0 +1,119 @@
+﻿namespace MBrace.Core.Tests
+
+open System
+open System.Threading
+
+open FsCheck
+
+open NUnit.Framework
+
+open MBrace.Core
+open MBrace.Core.Internals
+open MBrace.Store
+open MBrace.Store.Internals
+open MBrace.Workflows
+open MBrace.Client
+
+[<TestFixture>]
+[<Category("CollectionPartitioner")>]
+module ``Collection Partitioning Tests`` =
+
+    let imem = LocalRuntime.Create(ResourceRegistry.Empty)
+    let run c = imem.Run c
+
+    let mkDummyWorker id cores =
+        { 
+           new obj() with
+              member x.Equals(obj) =
+                match obj with :? IWorkerRef as w -> id = w.Id | _ -> false
+
+           interface IWorkerRef with
+              member x.CompareTo(obj: obj): int = 
+                match obj with :? IWorkerRef as w -> compare id w.Id | _ -> invalidArg "obj" "invalid comparand."
+              member x.Id: string = id
+              member x.ProcessorCount: int = cores
+              member x.Type: string = "dummy"
+        }
+
+    let concat (collections : seq<#ICloudCollection<'T>>) =
+        { new ICloudCollection<'T> with
+              member x.Count: Local<int64> = local { let! cs = collections |> Sequential.map (fun c -> c.Count) in return Array.sum cs}
+              member x.Size: Local<int64> = local { let! cs = collections |> Sequential.map (fun c -> c.Size) in return Array.sum cs}
+              member x.IsKnownCount: bool = collections |> Seq.forall (fun c -> c.IsKnownCount)
+              member x.IsKnownSize: bool = collections |> Seq.forall (fun c -> c.IsKnownSize)
+              member x.ToEnumerable(): Local<seq<'T>> = local { let! cs = collections |> Sequential.map (fun c -> c.ToEnumerable()) in return Seq.concat cs }
+        }
+
+    type RangeCollection(lower : int64, upper : int64, discloseSize : bool) =
+        static member Empty(discloseSize) = new RangeCollection(0L, -1L, discloseSize)
+        interface ICloudCollection<int64> with
+            member x.Count: Local<int64> = local { return upper - lower }
+            member x.IsKnownCount: bool = discloseSize
+            member x.IsKnownSize: bool = discloseSize
+            member x.Size: Local<int64> = local { return upper - lower }
+            member x.ToEnumerable(): Local<seq<int64>> = local { return seq { lower .. upper - 1L } }
+
+        override x.Equals y = obj.ReferenceEquals(x,y)
+        override x.GetHashCode() = (lower,upper).GetHashCode()
+
+    type PartitionableRangeCollection(lower : int64, upper : int64, discloseSize : bool) =
+        inherit RangeCollection(lower, upper, discloseSize)
+        interface IPartitionableCollection<int64> with
+            member x.GetPartitions(weights: int []): Local<ICloudCollection<int64> []> = local {
+                return
+                    Array.splitWeightedRange weights lower upper
+                    |> Array.map (function Some(l,u) -> new RangeCollection(l,u + 1L,discloseSize) :> ICloudCollection<int64>
+                                            | None -> RangeCollection.Empty(discloseSize) :> _)
+            }
+
+    [<Test>]
+    let ``Range collection tests`` () =
+        let tester (lower : int64, length : uint32) =
+            let length = int64 length
+            let upper = lower + length
+            let range = new RangeCollection(lower, upper, true) :> ICloudCollection<int64>
+            range.IsKnownSize |> shouldEqual true
+            range.Count |> run |> shouldEqual length
+            range.ToEnumerable() |> run |> Seq.length |> int64 |> shouldEqual length
+
+        Check.QuickThrowOnFail(tester)
+
+    [<Test>]
+    let ``Partitionable Range collection tests`` () =
+        let tester (lower : int64, length : uint32, weights : uint16 []) =
+            if weights = null || weights.Length = 0 then () else
+            let length = int64 length
+            let upper = lower + length
+            let weights = weights |> Array.map (fun i -> int i + 1)
+            let range = new PartitionableRangeCollection(lower, upper, true) :> IPartitionableCollection<int64>
+            let partitions = range.GetPartitions weights |> run
+            let partitionedSeqs = partitions |> Sequential.map (fun p -> p.ToEnumerable()) |> run |> Seq.concat
+            partitionedSeqs |> Seq.length |> int64 |> shouldEqual length
+
+        Check.QuickThrowOnFail(tester)
+
+    [<Test>]
+    let ``Partition collections that do not disclose size`` () =
+        let tester (isTargeted : bool, partitions : uint16, workers : uint16) =
+            let partitions = [| for p in 0us .. partitions -> RangeCollection.Empty(discloseSize = false) :> ICloudCollection<int64> |]
+            let workers = [| for w in 0us .. workers -> mkDummyWorker (string w) 4 |]
+            let partitionss = CloudCollection.PartitionBySize(workers, isTargeted, partitions) |> run
+            partitionss |> Array.map fst |> shouldEqual (workers |> Seq.take partitionss.Length |> Seq.toArray)
+            partitionss |> Array.collect snd |> shouldEqual partitions
+
+        Check.QuickThrowOnFail(tester)
+
+    [<Test>]
+    let ``Partition collections that disclose size`` () =
+        let tester (isTargeted : bool, sizes : uint32 [], workers : uint16) =
+            let partitions = [| for size in sizes -> new RangeCollection(0L, int64 size, discloseSize = true) :> ICloudCollection<int64> |]
+            let workers = [| for w in 0us .. workers -> mkDummyWorker (string w) 4 |]
+            let partitionss = CloudCollection.PartitionBySize(workers, isTargeted, partitions) |> run
+            partitionss |> Array.map fst |> shouldEqual (workers |> Seq.take partitionss.Length |> Seq.toArray)
+            partitionss |> Array.collect snd |> shouldEqual partitions
+
+        Check.QuickThrowOnFail(tester)
+
+    let isTargeted = true
+    let sizes = [|8u; 8u; 16u; 8u|]
+    let workers = 1us

--- a/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
+++ b/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
@@ -141,5 +141,5 @@ module ``Collection Partitioning Tests`` =
         Check.QuickThrowOnFail(tester, maxRuns = 500)
 
     let isTargeted = false
-    let totalSizes = [| 2L ; 1L |]
-    let workerCores = [|0us ; 0us ; 0us|]
+    let totalSizes = [|1L;1L|]
+    let workerCores = [|0us ; 0us |]

--- a/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
+++ b/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
@@ -99,7 +99,7 @@ module ``Collection Partitioning Tests`` =
             let partitions = [| for p in 0us .. partitions -> RangeCollection.Empty(discloseSize = false) :> ICloudCollection<int64> |]
             let workers = [| for w in 0us .. workers -> mkDummyWorker (string w) 4 |]
             let partitionss = CloudCollection.PartitionBySize(workers, isTargeted, partitions) |> run
-            partitionss |> Array.map fst |> shouldEqual (workers |> Seq.take partitionss.Length |> Seq.toArray)
+            partitionss |> Array.map fst |> shouldEqual workers
             partitionss |> Array.collect snd |> shouldEqual partitions
 
         Check.QuickThrowOnFail(tester, maxRuns = 500)
@@ -110,7 +110,7 @@ module ``Collection Partitioning Tests`` =
             let partitions = [| for size in sizes -> new RangeCollection(0L, int64 size, discloseSize = true) :> ICloudCollection<int64> |]
             let workers = [| for w in 0us .. workers -> mkDummyWorker (string w) 4 |]
             let partitionss = CloudCollection.PartitionBySize(workers, isTargeted, partitions) |> run
-            partitionss |> Array.map fst |> shouldEqual (workers |> Seq.take partitionss.Length |> Seq.toArray)
+            partitionss |> Array.map fst |> shouldEqual workers
             partitionss |> Array.collect snd |> shouldEqual partitions
 
         Check.QuickThrowOnFail(tester, maxRuns = 500)
@@ -139,7 +139,3 @@ module ``Collection Partitioning Tests`` =
             Array.sum sizes |> shouldEqual (totalSizes |> Array.sumBy (fun s -> abs s))
 
         Check.QuickThrowOnFail(tester, maxRuns = 500)
-
-    let isTargeted = false
-    let totalSizes = [|1L;1L|]
-    let workerCores = [|0us ; 0us |]

--- a/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
+++ b/tests/MBrace.Core.Tests/CollectionPartitionerTests.fs
@@ -18,6 +18,13 @@ open MBrace.Client
 [<Category("CollectionPartitioner")>]
 module ``Collection Partitioning Tests`` =
 
+    let fsCheckRetries =
+#if DEBUG
+        500
+#else
+        100
+#endif
+
     let imem = LocalRuntime.Create(ResourceRegistry.Empty)
     let run c = imem.Run c
 
@@ -89,7 +96,7 @@ module ``Collection Partitioning Tests`` =
             range.Count |> run |> shouldEqual length
             range.ToEnumerable() |> run |> Seq.length |> int64 |> shouldEqual length
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)
 
     [<Test>]
     let ``Partitionable Range collection tests`` () =
@@ -103,7 +110,7 @@ module ``Collection Partitioning Tests`` =
             let partitionedSeqs = partitions |> Sequential.map (fun p -> p.ToEnumerable()) |> run |> Seq.concat
             partitionedSeqs |> Seq.length |> int64 |> shouldEqual length
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)
 
     // Section 2: Actual partitioner tests
 
@@ -122,7 +129,7 @@ module ``Collection Partitioning Tests`` =
             |> int
             |> shouldBe (fun m -> abs (m - partitions.Length / workers.Length) <= 1)
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)
 
     [<Test>]
     let ``Partition collections that disclose size`` () =
@@ -133,7 +140,7 @@ module ``Collection Partitioning Tests`` =
             partitionss |> Array.map fst |> shouldEqual workers
             partitionss |> Array.collect snd |> shouldEqual partitions
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)
 
     [<Test>]
     let ``Partitionable collection simple`` () =
@@ -162,7 +169,7 @@ module ``Collection Partitioning Tests`` =
             |> run
             |> shouldEqual original
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)
 
     [<Test>]
     let ``Partitionable collections combined`` () =
@@ -194,7 +201,7 @@ module ``Collection Partitioning Tests`` =
             |> run
             |> shouldEqual original
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)
 
     [<Test>]
     let ``Heterogeneous collections`` () =
@@ -220,4 +227,4 @@ module ``Collection Partitioning Tests`` =
             |> run
             |> shouldEqual original
 
-        Check.QuickThrowOnFail(tester, maxRuns = 500)
+        Check.QuickThrowOnFail(tester, maxRuns = fsCheckRetries)

--- a/tests/MBrace.Core.Tests/ContinuationTests.fs
+++ b/tests/MBrace.Core.Tests/ContinuationTests.fs
@@ -607,7 +607,7 @@ module ``Continuation Tests`` =
             let arraySize = int arraySize
             let ts = [|1 .. arraySize|]
             let tss = Array.splitByPartitionCount partitionCount ts
-            tss.Length |> shouldEqual (min arraySize partitionCount)
+            tss.Length |> shouldEqual partitionCount
             Array.concat tss |> shouldEqual ts)
 
     [<Test>]

--- a/tests/MBrace.Core.Tests/MBrace.Core.Tests.fsproj
+++ b/tests/MBrace.Core.Tests/MBrace.Core.Tests.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Utils.fs" />
     <Compile Include="TestTypes.fs" />
     <Compile Include="ContinuationTests.fs" />
+    <Compile Include="CollectionPartitionerTests.fs" />
     <Compile Include="ParallelismTests.fs" />
     <Compile Include="StoreTests\FileStoreTests.fs" />
     <Compile Include="StoreTests\CloudAtomTests.fs" />

--- a/tests/MBrace.Core.Tests/StoreTests/FileStoreTests.fs
+++ b/tests/MBrace.Core.Tests/StoreTests/FileStoreTests.fs
@@ -168,7 +168,7 @@ type ``FileStore Tests`` (parallelismFactor : int) as self =
 
         let testPartitioning partitionCount =
             cloud {
-                let! partitions = cseq.GetPartitions partitionCount
+                let! partitions = cseq.GetPartitions (Array.init partitionCount (fun _ -> 4))
                 let! lines' = partitions |> DivideAndConquer.collect (fun e -> e.ToEnumerable())
                 lines'.Length |> shouldEqual 1000
                 lines' |> Array.iteri check 


### PR DESCRIPTION
This PR introduces a rewriting of the partitioning logic of cloud collections. This now takes partition sizes and worker capacities into account. A side-effect of this implementation is the unification of `CloudFlow.OfCloudFileByLine` and `CloudFlow.OfCloudFilesByLine` logics.