### PR TITLE
Simple method on CloudFile to create a new CloudFile from a Stream.

### DIFF
--- a/src/MBrace.Core/Store/CloudFileStore.fs
+++ b/src/MBrace.Core/Store/CloudFileStore.fs
@@ -649,13 +649,21 @@ type CloudFile =
     /// <param name="path">Path to Cloud file.</param>
     /// <param name="inputStream">The stream to read from. Assumes that the stream is already at the correct position for reading.</param>
     static member WriteStream(path : string, stream : Stream) : CloudLocal<CloudFileInfo> = local {
-        let! destination = CloudFile.BeginWrite path
-        do! (stream.CopyToAsync destination) |> Async.AwaitTaskCorrect |> Cloud.OfAsync
-
         let! store = Cloud.GetResource<ICloudFileStore>()
+        do! store.CopyOfStream(stream, path) |> Cloud.OfAsync
         return new CloudFileInfo(store, path)
     }
-        
+
+    /// <summary>
+    ///     Write the contents of a CloudFile directly to a Stream.
+    /// </summary>
+    /// <param name="path">Path to Cloud file.</param>
+    /// <param name="inputStream">The stream to write to.</param>
+    static member ReadStream(path : string, stream : Stream) : CloudLocal<unit> = local {
+        let! store = Cloud.GetResource<ICloudFileStore>()
+        return! store.CopyToStream(path, stream) |> Cloud.OfAsync
+    }
+
     /// <summary>
     ///     Store all contents of given file to a new byte array.
     /// </summary>

--- a/src/MBrace.Core/Store/CloudFileStore.fs
+++ b/src/MBrace.Core/Store/CloudFileStore.fs
@@ -642,6 +642,19 @@ type CloudFile =
         do! Cloud.OfAsync <| stream.AsyncWrite(buffer, 0, buffer.Length)
         return new CloudFileInfo(store, path)
     }
+
+    /// <summary>
+    ///     Write the contents of a stream directly to a CloudFile.
+    /// </summary>
+    /// <param name="path">Path to Cloud file.</param>
+    /// <param name="inputStream">The stream to read from. Assumes that the stream is already at the correct position for reading.</param>
+    static member WriteStream(path : string, stream : Stream) : CloudLocal<CloudFileInfo> = local {
+        let! destination = CloudFile.BeginWrite path
+        do! (stream.CopyToAsync destination) |> Async.AwaitTaskCorrect |> Cloud.OfAsync
+
+        let! store = Cloud.GetResource<ICloudFileStore>()
+        return new CloudFileInfo(store, path)
+    }
         
     /// <summary>
     ///     Store all contents of given file to a new byte array.


### PR DESCRIPTION
Provides a simple method on CloudFile that allows easy uploading to a CloudFile from any stream. This was functionality that existed in earlier versions of MBrace (albeit through a slightly more complex syntax).

Please review - not sure what the standards are with respect to unit tests etc. - let me know if there's anything expected.