### PR TITLE
Fix build 

### DIFF
--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -294,27 +294,27 @@ module Utils =
             else ValueOrException<'S>.NewException(input.Exception)
 
 
-// Thanks to http://blogs.msdn.com/b/jaredpar/archive/2010/07/27/converting-system-func-lt-t1-tn-gt-to-fsharpfunc-lt-t-tresult-gt.aspx
-[<Extension>]
-type public FSharpFuncUtil = 
+    // Thanks to http://blogs.msdn.com/b/jaredpar/archive/2010/07/27/converting-system-func-lt-t1-tn-gt-to-fsharpfunc-lt-t-tresult-gt.aspx
+    [<Extension>]
+    type public FSharpFuncUtil = 
 
-    [<Extension>] 
-    static member ToFSharpFunc<'a,'b> (func:System.Converter<'a,'b>) = fun x -> func.Invoke(x)
+        [<Extension>] 
+        static member ToFSharpFunc<'a,'b> (func:System.Converter<'a,'b>) = fun x -> func.Invoke(x)
 
-    [<Extension>] 
-    static member ToFSharpFunc<'a,'b> (func:System.Func<'a,'b>) = fun x -> func.Invoke(x)
+        [<Extension>] 
+        static member ToFSharpFunc<'a,'b> (func:System.Func<'a,'b>) = fun x -> func.Invoke(x)
 
-    [<Extension>] 
-    static member ToFSharpFunc<'a> (func:System.Func<'a>) = fun () -> func.Invoke()
+        [<Extension>] 
+        static member ToFSharpFunc<'a> (func:System.Func<'a>) = fun () -> func.Invoke()
 
-    [<Extension>] 
-    static member ToFSharpFunc<'a,'b,'c> (func:System.Func<'a,'b,'c>) = fun x y -> func.Invoke(x,y)
+        [<Extension>] 
+        static member ToFSharpFunc<'a,'b,'c> (func:System.Func<'a,'b,'c>) = fun x y -> func.Invoke(x,y)
 
-    [<Extension>] 
-    static member ToFSharpFunc<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = fun x y z -> func.Invoke(x,y,z)
+        [<Extension>] 
+        static member ToFSharpFunc<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = fun x y z -> func.Invoke(x,y,z)
 
-    static member Create<'a,'b> (func:System.Func<'a,'b>) = FSharpFuncUtil.ToFSharpFunc func
+        static member Create<'a,'b> (func:System.Func<'a,'b>) = FSharpFuncUtil.ToFSharpFunc func
 
-    static member Create<'a,'b,'c> (func:System.Func<'a,'b,'c>) = FSharpFuncUtil.ToFSharpFunc func
+        static member Create<'a,'b,'c> (func:System.Func<'a,'b,'c>) = FSharpFuncUtil.ToFSharpFunc func
 
-    static member Create<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = FSharpFuncUtil.ToFSharpFunc func
+        static member Create<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = FSharpFuncUtil.ToFSharpFunc func

--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -294,27 +294,27 @@ module Utils =
             else ValueOrException<'S>.NewException(input.Exception)
 
 
-    // Thanks to http://blogs.msdn.com/b/jaredpar/archive/2010/07/27/converting-system-func-lt-t1-tn-gt-to-fsharpfunc-lt-t-tresult-gt.aspx
-    [<Extension>]
-    type public FSharpFuncUtil = 
+// Thanks to http://blogs.msdn.com/b/jaredpar/archive/2010/07/27/converting-system-func-lt-t1-tn-gt-to-fsharpfunc-lt-t-tresult-gt.aspx
+[<Extension>]
+type public FSharpFuncUtil = 
 
-        [<Extension>] 
-        static member ToFSharpFunc<'a,'b> (func:System.Converter<'a,'b>) = fun x -> func.Invoke(x)
+    [<Extension>] 
+    static member ToFSharpFunc<'a,'b> (func:System.Converter<'a,'b>) = fun x -> func.Invoke(x)
 
-        [<Extension>] 
-        static member ToFSharpFunc<'a,'b> (func:System.Func<'a,'b>) = fun x -> func.Invoke(x)
+    [<Extension>] 
+    static member ToFSharpFunc<'a,'b> (func:System.Func<'a,'b>) = fun x -> func.Invoke(x)
 
-        [<Extension>] 
-        static member ToFSharpFunc<'a> (func:System.Func<'a>) = fun () -> func.Invoke()
+    [<Extension>] 
+    static member ToFSharpFunc<'a> (func:System.Func<'a>) = fun () -> func.Invoke()
 
-        [<Extension>] 
-        static member ToFSharpFunc<'a,'b,'c> (func:System.Func<'a,'b,'c>) = fun x y -> func.Invoke(x,y)
+    [<Extension>] 
+    static member ToFSharpFunc<'a,'b,'c> (func:System.Func<'a,'b,'c>) = fun x y -> func.Invoke(x,y)
 
-        [<Extension>] 
-        static member ToFSharpFunc<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = fun x y z -> func.Invoke(x,y,z)
+    [<Extension>] 
+    static member ToFSharpFunc<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = fun x y z -> func.Invoke(x,y,z)
 
-        static member Create<'a,'b> (func:System.Func<'a,'b>) = FSharpFuncUtil.ToFSharpFunc func
+    static member Create<'a,'b> (func:System.Func<'a,'b>) = FSharpFuncUtil.ToFSharpFunc func
 
-        static member Create<'a,'b,'c> (func:System.Func<'a,'b,'c>) = FSharpFuncUtil.ToFSharpFunc func
+    static member Create<'a,'b,'c> (func:System.Func<'a,'b,'c>) = FSharpFuncUtil.ToFSharpFunc func
 
-        static member Create<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = FSharpFuncUtil.ToFSharpFunc func
+    static member Create<'a,'b,'c,'d> (func:System.Func<'a,'b,'c,'d>) = FSharpFuncUtil.ToFSharpFunc func

--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -296,7 +296,7 @@ module Utils =
 
 // Thanks to http://blogs.msdn.com/b/jaredpar/archive/2010/07/27/converting-system-func-lt-t1-tn-gt-to-fsharpfunc-lt-t-tresult-gt.aspx
 [<Extension>]
-type internal FSharpFuncUtil = 
+type public FSharpFuncUtil = 
 
     [<Extension>] 
     static member ToFSharpFunc<'a,'b> (func:System.Converter<'a,'b>) = fun x -> func.Invoke(x)

--- a/src/MBrace.Core/Utils/Utils.fs
+++ b/src/MBrace.Core/Utils/Utils.fs
@@ -296,7 +296,7 @@ module Utils =
 
 // Thanks to http://blogs.msdn.com/b/jaredpar/archive/2010/07/27/converting-system-func-lt-t1-tn-gt-to-fsharpfunc-lt-t-tresult-gt.aspx
 [<Extension>]
-type public FSharpFuncUtil = 
+type internal FSharpFuncUtil = 
 
     [<Extension>] 
     static member ToFSharpFunc<'a,'b> (func:System.Converter<'a,'b>) = fun x -> func.Invoke(x)

--- a/src/MBrace.Flow.CSharp/CloudFlow.cs
+++ b/src/MBrace.Flow.CSharp/CloudFlow.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.FSharp.Core;
 using MBrace.Core.Internals;
+using static MBrace.Core.Internals.Utils;
 using MBrace.Flow.Internals;
 using System.IO;
 using MBrace.Core;

--- a/src/MBrace.Flow.CSharp/CloudFlow.cs
+++ b/src/MBrace.Flow.CSharp/CloudFlow.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.FSharp.Core;
 using MBrace.Core.Internals;
-using static MBrace.Core.Internals.Utils;
 using MBrace.Flow.Internals;
 using System.IO;
 using MBrace.Core;

--- a/src/MBrace.Flow.CSharp/CloudFlow.cs
+++ b/src/MBrace.Flow.CSharp/CloudFlow.cs
@@ -8,7 +8,6 @@ using MBrace.Core.Internals;
 using MBrace.Flow.Internals;
 using System.IO;
 using MBrace.Core;
-using static MBrace.Core.Internals.Utils.FSharpFuncUtil;
 
 namespace MBrace.Flow.CSharp
 {


### PR DESCRIPTION
The Mono C# compipler doesn't seem to find extension methods when you do "using static"